### PR TITLE
Feature/lunch #17

### DIFF
--- a/src/components/Common/ProgressBar/index.tsx
+++ b/src/components/Common/ProgressBar/index.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from 'react';
 import { css } from '@emotion/react';
 import React from 'react';
 
-interface ProgressBarProps {
+export interface ProgressBarProps {
   children?: ReactNode;
   min?: number;
   now?: number;

--- a/src/components/Layout/LunchLayout.tsx
+++ b/src/components/Layout/LunchLayout.tsx
@@ -1,0 +1,53 @@
+import type { ReactNode } from 'react';
+
+import { css } from '@emotion/react';
+
+const LunchLayout = ({ children }: { children: ReactNode }) => {
+  return (
+    <div css={baseCss}>
+      <div css={headerCss}>
+        <h2 css={titleCss}>icon 오늘의 점심</h2>
+        <span css={textCss}>
+          점심 맛있으셨나요? <br />
+          맛있는 만큼 따봉을 눌러주세요.
+        </span>
+      </div>
+      {children}
+    </div>
+  );
+};
+
+const baseCss = css({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 43,
+});
+
+// 이름에 대해 고민중
+const headerCss = css({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 43,
+});
+
+const titleCss = css({
+  fontSize: 17,
+  fontWeight: 700,
+  lineHeight: '22px',
+  letterSpacing: '-0.85px',
+  margin: '0 auto',
+});
+
+const textCss = css({
+  fontSize: 20,
+  fontWeight: 500,
+  lineHeight: '22.5px',
+  letterSpacing: '-1.25',
+});
+
+const linkCss = css({
+  textDecoration: 'none',
+  color: '#000',
+});
+
+export default LunchLayout;

--- a/src/components/Layout/MainLayout.tsx
+++ b/src/components/Layout/MainLayout.tsx
@@ -1,0 +1,23 @@
+import type { ReactNode } from 'react';
+
+import { css } from '@emotion/react';
+
+// 임시 레이아웃입니다.
+// 개발 단계에서, 보기 편하게 하기 위해서 넣어놨어요!
+const Layout = ({ children }: { children: ReactNode }) => {
+  return (
+    <div css={baseCss}>
+      {/* header ... */}
+      <main>{children}</main>
+    </div>
+  );
+};
+
+const baseCss = css({
+  width: '390px',
+  backgroundColor: '#eeeeee',
+  margin: '0 auto',
+  padding: '0 31px',
+});
+
+export default Layout;

--- a/src/components/Layout/MainLayout.tsx
+++ b/src/components/Layout/MainLayout.tsx
@@ -4,6 +4,7 @@ import { css } from '@emotion/react';
 
 // 임시 레이아웃입니다.
 // 개발 단계에서, 보기 편하게 하기 위해서 넣어놨어요!
+
 const Layout = ({ children }: { children: ReactNode }) => {
   return (
     <div css={baseCss}>
@@ -17,7 +18,7 @@ const baseCss = css({
   width: '390px',
   backgroundColor: '#eeeeee',
   margin: '0 auto',
-  padding: '0 31px',
+  padding: '0 30px',
 });
 
 export default Layout;

--- a/src/components/LunchCard/LikeProgress.tsx
+++ b/src/components/LunchCard/LikeProgress.tsx
@@ -2,7 +2,7 @@ import type { ProgressBarProps } from '../Common/ProgressBar';
 
 import { css } from '@emotion/react';
 
-import ProgressBar from '../Common/ProgressBar';
+import { ProgressBar } from '../Common';
 
 interface Props extends ProgressBarProps {}
 const LikeProgress = (props: Props) => {

--- a/src/components/LunchCard/LikeProgress.tsx
+++ b/src/components/LunchCard/LikeProgress.tsx
@@ -1,0 +1,35 @@
+import type { ProgressBarProps } from '../Common/ProgressBar';
+
+import { css } from '@emotion/react';
+
+import ProgressBar from '../Common/ProgressBar';
+
+interface Props extends ProgressBarProps {}
+const LikeProgress = (props: Props) => {
+  const { now } = props;
+  return (
+    <div css={baseCss}>
+      <span css={textCss}>{now}명이 좋아합니다.</span>
+      <ProgressBar
+        now={now}
+        backgroundColor="#F9F9F9"
+        foregroundColor="#9ADFA1"
+      />
+    </div>
+  );
+};
+
+const baseCss = css({
+  margin: '25px 18px 0',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '6px',
+});
+
+const textCss = css({
+  fontSize: '14px',
+  lineHeight: '20px',
+  color: '#fff',
+});
+
+export default LikeProgress;

--- a/src/components/LunchCard/LikeProgress.tsx
+++ b/src/components/LunchCard/LikeProgress.tsx
@@ -8,7 +8,7 @@ interface Props extends ProgressBarProps {}
 const LikeProgress = (props: Props) => {
   const { now } = props;
   return (
-    <div css={baseCss}>
+    <div css={selfCss}>
       <span css={textCss}>{now}명이 좋아합니다.</span>
       <ProgressBar
         now={now}
@@ -19,7 +19,7 @@ const LikeProgress = (props: Props) => {
   );
 };
 
-const baseCss = css({
+const selfCss = css({
   margin: '25px 18px 0',
   display: 'flex',
   flexDirection: 'column',

--- a/src/components/LunchCard/LunchCard.stories.tsx
+++ b/src/components/LunchCard/LunchCard.stories.tsx
@@ -1,0 +1,32 @@
+import type { LunchCardProps } from './index';
+import type { Meta, StoryObj } from '@storybook/react';
+
+import LunchCard from './index';
+
+const meta: Meta<LunchCardProps> = {
+  title: 'LunchCard',
+  component: LunchCard,
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<LunchCardProps>;
+
+export const Default: Story = {
+  args: {
+    checked: false,
+    place: '3층',
+    mainMenu: '돼지갈비',
+    extraMenu: '시금치, 계란말이, 아욱국',
+  },
+};
+
+export const Voted: Story = {
+  args: {
+    checked: true,
+    place: '3층',
+    mainMenu: '돼지갈비',
+    extraMenu: '시금치, 계란말이, 아욱국',
+  },
+};

--- a/src/components/LunchCard/Menu.tsx
+++ b/src/components/LunchCard/Menu.tsx
@@ -9,14 +9,14 @@ const Menu = (props: Props) => {
   const { mainMenu, extraMenu } = props;
 
   return (
-    <div css={baseCss}>
+    <div css={selfCss}>
       <span css={mainCss}>{mainMenu}</span>
       <span css={extraCss}>{extraMenu}</span>
     </div>
   );
 };
 
-const baseCss = css({
+const selfCss = css({
   paddingTop: 70,
   paddingLeft: 27,
   display: 'flex',

--- a/src/components/LunchCard/Menu.tsx
+++ b/src/components/LunchCard/Menu.tsx
@@ -1,0 +1,37 @@
+import { css } from '@emotion/react';
+
+interface Props {
+  mainMenu: string;
+  extraMenu: string;
+}
+
+const Menu = (props: Props) => {
+  const { mainMenu, extraMenu } = props;
+
+  return (
+    <div css={baseCss}>
+      <span css={mainCss}>{mainMenu}</span>
+      <span css={extraCss}>{extraMenu}</span>
+    </div>
+  );
+};
+
+const baseCss = css({
+  paddingTop: 70,
+  paddingLeft: 27,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '10px',
+});
+
+const mainCss = css({
+  fontSize: 31,
+  fontWeight: 700,
+});
+
+const extraCss = css({
+  fontSize: 15,
+  fontWeight: 700,
+});
+
+export default Menu;

--- a/src/components/LunchCard/Order.tsx
+++ b/src/components/LunchCard/Order.tsx
@@ -1,0 +1,36 @@
+import { css } from '@emotion/react';
+
+interface Props {
+  order: number;
+}
+
+const Order = ({ order }: Props) => {
+  return (
+    <div css={[baseCss]}>
+      <span
+        css={css`
+          position: absolute;
+          top: -55px;
+          left: 20px;
+          font-size: 20px;
+          font-weight: 500;
+          color: #fff;
+        `}
+      >
+        {order}
+      </span>
+    </div>
+  );
+};
+
+const baseCss = css({
+  position: 'absolute',
+  width: 0,
+  height: 0,
+  'border-top-left-radius': '10px',
+  'border-top': '65px solid #ffa7a7',
+  'border-left': '0px solid transparent',
+  'border-right': '65px solid transparent',
+});
+
+export default Order;

--- a/src/components/LunchCard/Order.tsx
+++ b/src/components/LunchCard/Order.tsx
@@ -6,7 +6,7 @@ interface Props {
 
 const Order = ({ order }: Props) => {
   return (
-    <div css={[baseCss]}>
+    <div css={[selfCss]}>
       <span
         css={css`
           position: absolute;
@@ -23,14 +23,14 @@ const Order = ({ order }: Props) => {
   );
 };
 
-const baseCss = css({
+const selfCss = css({
   position: 'absolute',
   width: 0,
   height: 0,
-  'border-top-left-radius': '10px',
-  'border-top': '65px solid #ffa7a7',
-  'border-left': '0px solid transparent',
-  'border-right': '65px solid transparent',
+  borderTopLeftRadius: 10,
+  borderTop: '65px solid #ffa7a7',
+  borderLeft: '0px solid transparent',
+  borderRight: '65px solid transparent',
 });
 
 export default Order;

--- a/src/components/LunchCard/Place.tsx
+++ b/src/components/LunchCard/Place.tsx
@@ -1,0 +1,20 @@
+import { css } from '@emotion/react';
+
+interface Props {
+  place: string;
+}
+const Place = ({ place }: Props) => {
+  return <span css={placeCss}>{place}</span>;
+};
+
+const placeCss = css({
+  position: 'absolute',
+  top: 28,
+  left: 39,
+  fontSize: 16,
+  fontWeight: 700,
+  letterSpacing: '-1.95px',
+  lineHeight: '40px',
+});
+
+export default Place;

--- a/src/components/LunchCard/Place.tsx
+++ b/src/components/LunchCard/Place.tsx
@@ -7,6 +7,7 @@ const Place = ({ place }: Props) => {
   return <span css={placeCss}>{place}</span>;
 };
 
+// todo absolute -> 다른 방식으로
 const placeCss = css({
   position: 'absolute',
   top: 28,

--- a/src/components/LunchCard/VoteButton.tsx
+++ b/src/components/LunchCard/VoteButton.tsx
@@ -15,7 +15,7 @@ const VoteButton = (props: Props) => {
 
   return (
     <button
-      css={baseCss}
+      css={selfCss}
       disabled={disabled}
       onClick={() => {
         // fetch
@@ -36,7 +36,7 @@ const VoteButton = (props: Props) => {
   );
 };
 
-const baseCss = css({
+const selfCss = css({
   position: 'absolute',
   width: '70px',
   height: '66px',

--- a/src/components/LunchCard/VoteButton.tsx
+++ b/src/components/LunchCard/VoteButton.tsx
@@ -1,0 +1,53 @@
+import type { ComponentPropsWithoutRef } from 'react';
+
+import { css } from '@emotion/react';
+
+import { toCssVar } from '~/styles/utils';
+
+interface Props extends ComponentPropsWithoutRef<'button'> {
+  checked?: boolean;
+  loading?: boolean;
+  disabled?: boolean;
+}
+
+const VoteButton = (props: Props) => {
+  const { checked = false, loading = false, disabled = false } = props;
+
+  return (
+    <button
+      css={baseCss}
+      disabled={disabled}
+      onClick={() => {
+        // fetch
+      }}
+      // dynamic style에 대해 협으이할 필요
+      style={{ backgroundColor: checked ? '#9ADFA1' : '#D1D1D1' }}
+    >
+      <span
+        css={css`
+          font-size: 10px;
+          color: #fff;
+        `}
+      >
+        {/* Icon */}
+        맛있어요!
+      </span>
+    </button>
+  );
+};
+
+const baseCss = css({
+  position: 'absolute',
+  width: '70px',
+  height: '66px',
+  top: '34px',
+  left: '223px',
+  'border-radius': '100%',
+  display: 'flex',
+  'align-items': 'center',
+  'justify-content': 'center',
+  'flex-direction': 'column',
+  cursor: 'pointer',
+});
+
+export default VoteButton;

--- a/src/components/LunchCard/VoteButton.tsx
+++ b/src/components/LunchCard/VoteButton.tsx
@@ -15,12 +15,11 @@ const VoteButton = (props: Props) => {
 
   return (
     <button
-      css={selfCss}
+      css={[selfCss, checked ? highLightCss : defaultCss]}
       disabled={disabled}
       onClick={() => {
         // fetch
       }}
-      style={{ backgroundColor: checked ? '#9ADFA1' : '#D1D1D1' }}
     >
       <span
         css={css`
@@ -47,6 +46,14 @@ const selfCss = css({
   justifyContent: 'center',
   flexDirection: 'column',
   cursor: 'pointer',
+});
+
+const highLightCss = css({
+  background: '#9ADFA1',
+});
+
+const defaultCss = css({
+  background: '#D1D1D1',
 });
 
 export default VoteButton;

--- a/src/components/LunchCard/VoteButton.tsx
+++ b/src/components/LunchCard/VoteButton.tsx
@@ -20,7 +20,6 @@ const VoteButton = (props: Props) => {
       onClick={() => {
         // fetch
       }}
-      // dynamic style에 대해 협으이할 필요
       style={{ backgroundColor: checked ? '#9ADFA1' : '#D1D1D1' }}
     >
       <span
@@ -42,11 +41,11 @@ const selfCss = css({
   height: '66px',
   top: '34px',
   left: '223px',
-  'border-radius': '100%',
+  borderRadius: '100%',
   display: 'flex',
-  'align-items': 'center',
-  'justify-content': 'center',
-  'flex-direction': 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  flexDirection: 'column',
   cursor: 'pointer',
 });
 

--- a/src/components/LunchCard/index.tsx
+++ b/src/components/LunchCard/index.tsx
@@ -7,32 +7,7 @@ import Order from './Order';
 import Place from './Place';
 import VoteButton from './VoteButton';
 
-interface Data {
-  lunchId?: string;
-  mainMenu: string;
-  extraMenu: string;
-  menuUrl?: string;
-  menuKcal?: string;
-  uploadAt?: Date;
-  // place는 정해지지 않았지만, 필요하다고 생각함.
-  place?: string;
-}
-
-export interface LunchCardProps extends Data {
-  checked?: boolean;
-  now?: number;
-  // fetch data
-}
-
-const baseCss = css({
-  position: 'relative',
-  width: 325,
-  height: 226,
-  backgroundColor: '#999999',
-  borderRadius: 10,
-});
-
-const LunchCard = (props: LunchCardProps) => {
+const LunchCard = (props: any) => {
   const { checked = false, place, mainMenu, extraMenu } = props;
   return (
     <div css={baseCss}>
@@ -44,5 +19,13 @@ const LunchCard = (props: LunchCardProps) => {
     </div>
   );
 };
+
+const baseCss = css({
+  position: 'relative',
+  width: 325,
+  height: 226,
+  backgroundColor: '#999999',
+  borderRadius: 10,
+});
 
 export default LunchCard;

--- a/src/components/LunchCard/index.tsx
+++ b/src/components/LunchCard/index.tsx
@@ -1,0 +1,48 @@
+import { css } from '@emotion/react';
+import React from 'react';
+
+import LikeProgress from './LikeProgress';
+import Menu from './Menu';
+import Order from './Order';
+import Place from './Place';
+import VoteButton from './VoteButton';
+
+interface Data {
+  lunchId?: string;
+  mainMenu: string;
+  extraMenu: string;
+  menuUrl?: string;
+  menuKcal?: string;
+  uploadAt?: Date;
+  // place는 정해지지 않았지만, 필요하다고 생각함.
+  place?: string;
+}
+
+export interface LunchCardProps extends Data {
+  checked?: boolean;
+  now?: number;
+  // fetch data
+}
+
+const baseCss = css({
+  position: 'relative',
+  width: 325,
+  height: 226,
+  backgroundColor: '#999999',
+  borderRadius: 10,
+});
+
+const LunchCard = (props: LunchCardProps) => {
+  const { checked = false, place, mainMenu, extraMenu } = props;
+  return (
+    <div css={baseCss}>
+      <VoteButton checked={checked} />
+      <Order order={1} />
+      <Place place="3층" />
+      <Menu mainMenu={mainMenu} extraMenu={extraMenu} />
+      <LikeProgress now={80} />
+    </div>
+  );
+};
+
+export default LunchCard;

--- a/src/components/LunchCard/index.tsx
+++ b/src/components/LunchCard/index.tsx
@@ -10,7 +10,7 @@ import VoteButton from './VoteButton';
 const LunchCard = (props: any) => {
   const { checked = false, place, mainMenu, extraMenu } = props;
   return (
-    <div css={baseCss}>
+    <div css={selfCss}>
       <VoteButton checked={checked} />
       <Order order={1} />
       <Place place="3층" />
@@ -20,7 +20,7 @@ const LunchCard = (props: any) => {
   );
 };
 
-const baseCss = css({
+const selfCss = css({
   position: 'relative',
   width: 325,
   height: 226,

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -5,6 +5,7 @@ import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { useState } from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 
+import Layout from '~/components/Layout/MainLayout';
 import getQueryClient from '~/react-query/common/queryClient';
 import { store } from '~/store';
 import GlobalStyles from '~/styles/GlobalStyles';
@@ -22,7 +23,9 @@ export default function App({ Component, pageProps }: AppProps) {
       <Hydrate state={pageProps.dehydratedState}>
         <ReduxProvider store={store}>
           <GlobalStyles />
-          <Component {...pageProps} />
+          <Layout>
+            <Component {...pageProps} />
+          </Layout>
         </ReduxProvider>
       </Hydrate>
     </QueryClientProvider>

--- a/src/pages/lunch.tsx
+++ b/src/pages/lunch.tsx
@@ -1,0 +1,78 @@
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+
+import { css } from '@emotion/react';
+import React from 'react';
+
+import LunchLayout from '~/components/Layout/LunchLayout';
+import LunchCard from '~/components/LunchCard';
+
+const Lunch = ({ data }: any) => {
+  const router = useRouter();
+  return (
+    <LunchLayout>
+      <div>Select Box</div>
+      <div
+        css={css`
+          display: flex;
+          justify-content: center;
+        `}
+      >
+        <Link
+          href={{
+            pathname: '/lunch',
+            query: { date: 'today' },
+          }}
+          css={[textCss, linkCss]}
+          style={router.query.date === 'today' ? { color: 'blue' } : undefined}
+        >
+          오늘
+        </Link>
+        <span>디바이더</span>
+        <Link
+          href={{
+            pathname: '/lunch',
+            query: { date: 'tomorrow' },
+          }}
+          css={[textCss, linkCss]}
+          style={
+            router.query.date === 'tomorrow' ? { color: 'blue' } : undefined
+          }
+        >
+          내일
+        </Link>
+      </div>
+      <div
+        css={css`
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          gap: 17px;
+        `}
+      >
+        <LunchCard checked mainMenu="돼지갈비" extraMenu="시금치" />
+        <LunchCard mainMenu="돼지갈비" extraMenu="시금치" />
+      </div>
+    </LunchLayout>
+  );
+};
+
+const textCss = css({
+  fontSize: 20,
+  fontWeight: 500,
+  lineHeight: '22.5px',
+  letterSpacing: '-1.25',
+});
+
+const linkCss = css({
+  textDecoration: 'none',
+  color: '#000',
+});
+
+export default Lunch;
+
+export async function getServerSideProps() {
+  return {
+    props: { data: 1 },
+  };
+}

--- a/src/pages/lunch/index.tsx
+++ b/src/pages/lunch/index.tsx
@@ -23,8 +23,11 @@ const Lunch = ({ data }: any) => {
             pathname: '/lunch',
             query: { date: 'today' },
           }}
-          css={[textCss, linkCss]}
-          style={router.query.date === 'today' ? { color: 'blue' } : undefined}
+          css={[
+            textCss,
+            linkCss,
+            router.query.date === 'today' ? highLightCss : undefined,
+          ]}
         >
           오늘
         </Link>
@@ -34,10 +37,11 @@ const Lunch = ({ data }: any) => {
             pathname: '/lunch',
             query: { date: 'tomorrow' },
           }}
-          css={[textCss, linkCss]}
-          style={
-            router.query.date === 'tomorrow' ? { color: 'blue' } : undefined
-          }
+          css={[
+            textCss,
+            linkCss,
+            router.query.date === 'tomorrow' ? highLightCss : undefined,
+          ]}
         >
           내일
         </Link>
@@ -67,6 +71,10 @@ const textCss = css({
 const linkCss = css({
   textDecoration: 'none',
   color: '#000',
+});
+
+const highLightCss = css({
+  color: 'blue',
 });
 
 export default Lunch;

--- a/src/styles/GlobalStyles.tsx
+++ b/src/styles/GlobalStyles.tsx
@@ -95,6 +95,7 @@ const resetCss = css`
     font-size: 100%;
     font: inherit;
     vertical-align: baseline;
+    box-sizing: border-box;
   }
   /* HTML5 display-role reset for older browsers */
   article,

--- a/src/styles/GlobalStyles.tsx
+++ b/src/styles/GlobalStyles.tsx
@@ -143,6 +143,10 @@ const customBaseCss = css`
     outline: 0;
     border: 0;
   }
+
+  * {
+    box-sizing: border-box;
+  }
 `;
 
 export default GlobalStyles;

--- a/src/styles/GlobalStyles.tsx
+++ b/src/styles/GlobalStyles.tsx
@@ -95,7 +95,6 @@ const resetCss = css`
     font-size: 100%;
     font: inherit;
     vertical-align: baseline;
-    box-sizing: border-box;
   }
   /* HTML5 display-role reset for older browsers */
   article,


### PR DESCRIPTION
## Issues

- #17 

<!-- 이슈 번호를 작성해주세요. 여러 이슈 번호를 작성해도 됩니다. -->

## 구분

- [ ] 버그 수정
- [x] 기능 추가
- [ ] 코드 리팩터링
- [ ] 문서 업데이트
- [ ] 기타

<!-- 어떤 이유로 코드를 변경했는지 체크해주세요. -->

## 주요 변경점

- Lunch Card 컴포넌트를 추가했습니다. (Storybook에서 확인해보실 수 있어요!)
- 글로벌 Css에 `box-sizing: border-box`를 추가했습니다.
- 개발단계에서, 편하게 하기 위해 `MainPage Layout`을 임시로 구현해 넣어뒀어요. 

<!-- 주요 변경점과 어떤 부분을 집중해서 리뷰해야 하는지 알려주세요. -->

## 스크린샷


<!-- 관련 미디어 파일이 있으면 첨부해주세요. -->

## 기타

<!-- 추가로 전달할 내용, 메모할 내용, 테스트 계획, 완료된 테스트 등을 알려주세요. -->

- 이번에 작업을 하면서, 개인적으로 신경쓸만한 부분이라고 생각했던 부분은 다음과 같아요.

### Style 관련
`style`관련은 이전에 논의해두었던 부분과 함께, [emotion 공식문서](https://emotion.sh/docs/best-practices)를 참고해 진행하고 있어요.
- `Dynamic Style`을 어떻게 적용할 지 구체적으로 논의해볼 필요가 있는 것 같아요.
- 그런데 진행하고 있는 스타일링 방식에서, 
  - 이름짓기 불편함
  - 하위 요소에 대한 접근을 할 수 없음   
  
```css
 .avata {
  span {
    color: #fff
   /**
   하위 모든 text color는, 하얀색이에요.
  이런 방식의 스타일링이 되지 않으니 모든 컴포넌트에 색상을 입혀놔야 했답니다.
  다크모드를 고려한다면, 다크모드 색상까지 두배의 중복코드가 만들어질 것이라 생각합니다.
  **/
  }
}
```
위의 두가지 부분에서 아쉬움을 느꼈습니다. 해당 부분은 해소할 방법은 따로 없겠죠? ( 사실 상관은 없답니다! 미리 정해둔 컨벤션이 더 중요하다고 생각해요. )

- 덧붙여, 추후에 반응형으로 연계될 점을 고려한다면 `em, erm`과 같은 상대단위의 도입을 생각해볼 필요가 있을 것 같아요.
- 또한, 기존 디자인에 수평일 잘 맞지 않는 부분 - 왼쪽 30px, 오른쪽 35px의 마진 - 과 같은 부분이 있었어요. 기획, 디자인 분들이 바쁘시므로 따로 말씀드리진 않을 것 같고, 제가 임의로 수평을 맞춰 진행했습니다.

### Data Fetching 관련
`mock, data` 관련 부분은 숙지했으나 아직 작업하지 않았어요. 작업하지 않은 이유는 다음과 같아요.
- 아직 `erd`설계가 확정되지 않은 것 같아요. 이전에 물어봤던 내용도 있지만 지속적으로 `erd cloud`를 확인하고 있으나, 확정되진 않은 것 같다고 판단했습니다.
- `좋아요의 수`, `식사 장소` 등의 부분은 아직 존재하지 않는 것 같다 판단했습니다. (해당 내용은 추후에 진행하실 것 같아, 확정되고 진행해도 나쁘지 않다 생각했습니다. )

- 다만, 해당 페이지는 `isr + client` 데이터 페칭이 적절하다고 생각했습니다.


위와 같이 생각한 이유는, 다음과 같아요.

 - 식사 메뉴를 보여주는 내용은 단순히 데이터를 내려주는 것과 동일하기 때문이에요.
 - isr를 사용할 시 특정 시간에 다시 데이터를 불러와 빌드하는 로직을 개발자가 직접 작성할 필요가 없기 때문이에요. (vercel 에서 이 부분이 가능하다고는 알고 있어요. )
 - 사용자가 유지된다면, isr을 통한 build에 문제가 없다고 판단했기 때문이에요.
 - `좋아요`가 달라질 경우 `ssr`을 사용할때 페이지 전체를 다시 빌드해야하는 부분이 비효율적이라고 생각했기 때문이에요.

다만 다음과 같은 문제점도 있습니다.
- 사용자가 유지되지 않는다면, 너무 늦은 시점에 페이지가 다시 빌드될 수 있어요.
 
isr의 경우 마지막 사용자가 해당페이지에 접근 -> 데이터가 달라졌다 판단됨 / stale 시간이 지나있음 
이 조건들이 모두 이루어져야 될텐데, 마지막 사용자가 너무 늦은 시간에 접근했다면 의도치 않게 늦게 빌드될 수 있습니다.

### 기획 관련
캠퍼스 별로, 다른 메뉴가 보여지는 부분은 `query`를 활용해 진행할 예정입니다.
사소한 부분이긴 하지만, 사용자의 캠퍼스가 저장되어 있을 것이라 예측하고 해당 정보가 있다면 `default`로 해당 정보를 미리 보여줄 수 있을 것이라 생각되요. 구현하는 데에 조금 귀찮은 부분은 있겠지만요.
중요한 기획 관련 내용은 아니므로, 읽고 넘어가셔도 괜찮답니다.
