### PR TITLE
`<AuthChecker />`구현, Nextjs type 확장

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --port 8081",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/src/components/AuthChecker/index.tsx
+++ b/src/components/AuthChecker/index.tsx
@@ -1,6 +1,10 @@
 import type { NextPageAuthConfig } from 'next/types';
 import type { ReactNode } from 'react';
 
+import { useRouter } from 'next/router';
+
+import { role, useMyInfo } from '~/services/member';
+
 export interface AuthCheckerProps {
   auth: NextPageAuthConfig;
   children: ReactNode;
@@ -9,7 +13,27 @@ export interface AuthCheckerProps {
 const AuthChecker = (props: AuthCheckerProps) => {
   const { auth, children } = props;
 
+  const router = useRouter();
+  const { data: myInfo, isLoading, isError } = useMyInfo();
+
+  if (isLoading) {
+    return auth.loading || <DefaultLoadingComponent />;
+  }
+
+  const isUnauthorized =
+    isError || role(myInfo.role).hasLowerAuthorityThan(auth.role);
+
+  if (isUnauthorized) {
+    if (typeof auth.unauthorized === 'string') {
+      router.replace(auth.unauthorized);
+    }
+
+    return auth.unauthorized;
+  }
+
   return <>{children}</>;
 };
+
+const DefaultLoadingComponent = () => <div>로딩중</div>;
 
 export default AuthChecker;

--- a/src/components/AuthChecker/index.tsx
+++ b/src/components/AuthChecker/index.tsx
@@ -1,5 +1,5 @@
 import type { NextPageAuthConfig } from 'next/types';
-import type { ReactNode } from 'react';
+import type { FC, ReactNode } from 'react';
 
 import { useRouter } from 'next/router';
 
@@ -28,7 +28,7 @@ const AuthChecker = (props: AuthCheckerProps) => {
       router.replace(auth.unauthorized);
     }
 
-    return auth.unauthorized;
+    return <>{auth.unauthorized}</>;
   }
 
   return <>{children}</>;

--- a/src/components/AuthChecker/index.tsx
+++ b/src/components/AuthChecker/index.tsx
@@ -1,0 +1,15 @@
+import type { NextPageAuthConfig } from 'next/types';
+import type { ReactNode } from 'react';
+
+export interface AuthCheckerProps {
+  auth: NextPageAuthConfig;
+  children: ReactNode;
+}
+
+const AuthChecker = (props: AuthCheckerProps) => {
+  const { auth, children } = props;
+
+  return <>{children}</>;
+};
+
+export default AuthChecker;

--- a/src/mocks/handlers/auth/data.ts
+++ b/src/mocks/handlers/auth/data.ts
@@ -1,0 +1,55 @@
+import cookie from 'js-cookie';
+
+import { RESPONSE } from '~/utils';
+
+export const ACCESS_TOKEN_KEY = 'msw-access-token';
+export const REFRESH_TOKEN_KEY = 'msw-refresh-token';
+export const TOKEN_VALUE = '.';
+export const EXPIRED_TOKEN_VALUE = '..';
+
+export const issueTokens = () => {
+  cookie.set(ACCESS_TOKEN_KEY, TOKEN_VALUE, {
+    expires: 0.25 / 24, // 15분
+  });
+  cookie.set(REFRESH_TOKEN_KEY, TOKEN_VALUE, {
+    expires: 14, // 14일
+  });
+};
+
+export const removeTokens = () => {
+  cookie.remove(ACCESS_TOKEN_KEY);
+  cookie.remove(REFRESH_TOKEN_KEY);
+};
+
+const checkTokenError = (token: string | undefined) => {
+  if (token === TOKEN_VALUE) {
+    return undefined;
+  }
+
+  if (token === EXPIRED_TOKEN_VALUE) {
+    return {
+      code: RESPONSE.CODE.EXPIRED_TOKEN,
+      message: '',
+      data: {},
+    };
+  }
+
+  return {
+    code: RESPONSE.CODE.INVALID_TOKEN,
+    message: '',
+    data: {},
+  };
+};
+
+/**
+ * - 브라우저에 세팅되어 있는 mocking된 access token을 확인합니다.
+ * - 오류가 없으면 undefined를 반환합니다.
+ * - 오류가 있는 경우 서버에서 응답할 것으로 예상되는 data를 반환합니다.
+ */
+export const checkAccessTokenError = () => {
+  return checkTokenError(cookie.get(ACCESS_TOKEN_KEY));
+};
+
+export const checkRefreshTokenError = () => {
+  return checkTokenError(cookie.get(REFRESH_TOKEN_KEY));
+};

--- a/src/mocks/handlers/auth/index.ts
+++ b/src/mocks/handlers/auth/index.ts
@@ -1,33 +1,15 @@
 import type { SignInApiData } from '~/services/auth';
 
-import cookie from 'js-cookie';
 import { rest } from 'msw';
 
 import {
-  mockExpiredTokenError,
-  mockInvalidTokenError,
-  mockSuccess,
-} from '~/mocks/utils';
+  issueTokens,
+  removeTokens,
+  checkRefreshTokenError,
+} from '~/mocks/handlers/auth/data';
+import { mockError, mockSuccess } from '~/mocks/utils';
 import { endpoints } from '~/react-query/common';
 import { API_URL, composeUrls } from '~/utils';
-
-const ACCESS_TOKEN_KEY = 'msw-access-token';
-const REFRESH_TOKEN_KEY = 'msw-refresh-token';
-const TOKEN_VALUE = '.';
-const EXPIRED_TOKEN_VALUE = '..';
-
-const issueTokens = () => {
-  cookie.set(ACCESS_TOKEN_KEY, TOKEN_VALUE, {
-    expires: 1 / 24, // 1시간
-  });
-  cookie.set(REFRESH_TOKEN_KEY, TOKEN_VALUE, {
-    expires: 14, // 14일
-  });
-};
-const removeTokens = () => {
-  cookie.remove(ACCESS_TOKEN_KEY);
-  cookie.remove(REFRESH_TOKEN_KEY);
-};
 
 const signIn = rest.post<never, never, SignInApiData>(
   composeUrls(API_URL, endpoints.auth.signIn()),
@@ -50,23 +32,15 @@ const signOut = rest.post(
 const reissueToken = rest.post(
   composeUrls(API_URL, endpoints.auth.refresh()),
   (req, res, ctx) => {
-    const refreshToken = cookie.get(REFRESH_TOKEN_KEY);
+    const error = checkRefreshTokenError();
 
-    if (refreshToken === TOKEN_VALUE) {
-      // 토큰이 유효함
-      issueTokens();
-      return res(...mockSuccess(ctx, {}));
+    if (error) {
+      return res(...mockError(ctx, error.code));
     }
 
-    if (refreshToken === EXPIRED_TOKEN_VALUE) {
-      // 토큰이 만료됨 (토큰 값을 ..로 세팅 후 보내면 됨)
-      // removeTokens();
-      return res(...mockExpiredTokenError(ctx));
-    }
-
-    // 토큰이 유효하지 않음 (위조, 없음 등)
-    // removeTokens();
-    return res(...mockInvalidTokenError(ctx));
+    // 토큰이 유효함
+    issueTokens();
+    return res(...mockSuccess(ctx, {}));
   }
 );
 

--- a/src/mocks/handlers/index.ts
+++ b/src/mocks/handlers/index.ts
@@ -1,2 +1,3 @@
 export * from './examples';
 export * from './auth';
+export * from './member';

--- a/src/mocks/handlers/member/index.ts
+++ b/src/mocks/handlers/member/index.ts
@@ -6,12 +6,12 @@ import { mockSuccess } from '~/mocks/utils';
 import { endpoints } from '~/react-query/common';
 import { API_URL, composeUrls } from '~/utils';
 
-const getMyInfo = rest.post<never, never, GetMyInfoApiData>(
+const getMyInfo = rest.get<never, never, GetMyInfoApiData>(
   composeUrls(API_URL, endpoints.user.myInfo()),
   (req, res, ctx) => {
     return res(
       ctx.delay(500),
-      ...mockSuccess<GetMyInfoData>(ctx, { role: 'admin' })
+      ...mockSuccess<GetMyInfoData>(ctx, { role: 'user' })
     );
   }
 );

--- a/src/mocks/handlers/member/index.ts
+++ b/src/mocks/handlers/member/index.ts
@@ -1,0 +1,19 @@
+import type { GetMyInfoApiData, GetMyInfoData } from '~/services/member';
+
+import { rest } from 'msw';
+
+import { mockSuccess } from '~/mocks/utils';
+import { endpoints } from '~/react-query/common';
+import { API_URL, composeUrls } from '~/utils';
+
+const getMyInfo = rest.post<never, never, GetMyInfoApiData>(
+  composeUrls(API_URL, endpoints.user.myInfo()),
+  (req, res, ctx) => {
+    return res(
+      ctx.delay(500),
+      ...mockSuccess<GetMyInfoData>(ctx, { role: 'admin' })
+    );
+  }
+);
+
+export const memberHandlers = [getMyInfo];

--- a/src/mocks/index.ts
+++ b/src/mocks/index.ts
@@ -1,7 +1,7 @@
 export async function initBrowserMocks() {
   if (typeof window !== 'undefined') {
     const { worker } = await import('./browser');
-    worker.start();
+    await worker.start();
   }
 }
 

--- a/src/mocks/utils.ts
+++ b/src/mocks/utils.ts
@@ -12,8 +12,8 @@ import { RESPONSE } from '~/utils';
 export const mockSuccess = <D>(
   ctx: RestContext,
   data: D,
-  message = '',
   code = '',
+  message = '',
   statusCode = 200
 ) => {
   const isValidStatusCode = statusCode >= 200 && statusCode < 400;
@@ -28,15 +28,15 @@ export const mockSuccess = <D>(
 };
 
 /**
- * - 실패 응답에 거의 `message`만 사용되기 때문에 만들었습니다.
+ * - 실패 응답에 거의 `code`, `message`만 사용되기 때문에 만들었습니다.
  * - `resolver`의 반환값으로 사용하면 됩니다.
  * @example
- *   return res(...mockError(ctx, 'error-message'))
+ *   return res(...mockError(ctx, 'error-code', 'error-message'))
  */
 export const mockError = (
   ctx: RestContext,
-  message: string,
   code = '',
+  message = '',
   statusCode = 400
 ) => {
   const isValidStatusCode = statusCode >= 400 && statusCode < 600;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,10 +1,11 @@
-import type { AppProps } from 'next/app';
+import type { CustomAppProps } from 'next/app';
 
 import { QueryClientProvider, Hydrate } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { useState } from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 
+import AuthChecker from '~/components/AuthChecker';
 import { MainLayout } from '~/components/Layout';
 import useMSW from '~/hooks/useMSW';
 import { initServerMocks } from '~/mocks';
@@ -14,7 +15,7 @@ import GlobalStyles from '~/styles/GlobalStyles';
 
 initServerMocks();
 
-export default function App({ Component, pageProps }: AppProps) {
+export default function App({ Component, pageProps }: CustomAppProps) {
   const [queryClient] = useState(getQueryClient);
   const isMSWReady = useMSW();
 
@@ -29,7 +30,13 @@ export default function App({ Component, pageProps }: AppProps) {
         <ReduxProvider store={store}>
           <GlobalStyles />
           <MainLayout>
-            <Component {...pageProps} />
+            {Component.auth ? (
+              <AuthChecker auth={Component.auth}>
+                <Component {...pageProps} />
+              </AuthChecker>
+            ) : (
+              <Component {...pageProps} />
+            )}
           </MainLayout>
         </ReduxProvider>
       </Hydrate>

--- a/src/pages/auth/register/index.tsx
+++ b/src/pages/auth/register/index.tsx
@@ -1,6 +1,8 @@
+import type { CustomNextPage } from 'next/types';
+
 import UserRegister from '~/components/UserRegister';
 
-const Register = () => {
+const RegisterPage: CustomNextPage = () => {
   return (
     <div>
       <UserRegister />
@@ -8,4 +10,10 @@ const Register = () => {
   );
 };
 
-export default Register;
+RegisterPage.auth = {
+  role: 'user',
+  loading: <div>Loading</div>,
+  unauthorized: <div>Unauthorized</div>,
+};
+
+export default RegisterPage;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,20 +1,11 @@
 import type { GetServerSideProps } from 'next/types';
 
-import { Inter } from 'next/font/google';
 import Head from 'next/head';
-
-import { useQuery } from '@tanstack/react-query';
 
 import Counter from '~/components/Counter';
 import { prefetch } from '~/react-query/server/prefetch';
 
-const inter = Inter({ subsets: ['latin'] });
-
-export default function Home() {
-  const { data } = useQuery(['example'], queryFn);
-
-  console.log(data);
-
+const HomePage = () => {
   return (
     <>
       <Head>
@@ -23,13 +14,15 @@ export default function Home() {
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="icon" href="/favicon.ico" />
       </Head>
-      <main className={`${inter.className}`}>
+      <main>
         {/* Redux */}
         <Counter />
       </main>
     </>
   );
-}
+};
+
+export default HomePage;
 
 const queryFn = async () => {
   const res = await fetch('https://jsonplaceholder.typicode.com/todos');

--- a/src/react-query/common/queryKeys.ts
+++ b/src/react-query/common/queryKeys.ts
@@ -1,5 +1,8 @@
 export const queryKeys = {
   todos: (id: string) => ['todos', { id }],
+  user: {
+    myInfo: () => ['myInfo'],
+  },
 };
 
 export const endpoints = {
@@ -7,5 +10,8 @@ export const endpoints = {
     signIn: () => '/auth/login' as const,
     signOut: () => '/auth/logout' as const,
     refresh: () => '/auth/reissue' as const,
+  },
+  user: {
+    myInfo: () => '/members' as const,
   },
 };

--- a/src/services/member/apis.ts
+++ b/src/services/member/apis.ts
@@ -1,0 +1,18 @@
+import type { UserRole } from '~/services/member/utils';
+import type { ApiSuccessResponse } from '~/types';
+
+import { endpoints } from '~/react-query/common';
+import { privateAxios } from '~/utils';
+
+export interface GetMyInfoData {
+  role: UserRole;
+}
+
+export type GetMyInfoApiData = ApiSuccessResponse<GetMyInfoData>;
+
+export const getMyInfo = () => {
+  const endpoint = endpoints.user.myInfo();
+  return privateAxios
+    .get<GetMyInfoApiData>(endpoint)
+    .then((res) => res.data.data);
+};

--- a/src/services/member/hooks.ts
+++ b/src/services/member/hooks.ts
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { queryKeys } from '~/react-query/common';
+
+import { getMyInfo } from './apis';
+
+export const useMyInfo = () => {
+  return useQuery({
+    queryKey: queryKeys.user.myInfo(),
+    queryFn: getMyInfo,
+  });
+};
+
+export const useIsAuthenticated = () => {
+  const { data } = useMyInfo();
+
+  return Boolean(data);
+};

--- a/src/services/member/index.ts
+++ b/src/services/member/index.ts
@@ -1,0 +1,1 @@
+export * from './utils';

--- a/src/services/member/index.ts
+++ b/src/services/member/index.ts
@@ -1,1 +1,3 @@
+export * from './apis';
+export * from './hooks';
 export * from './utils';

--- a/src/services/member/utils.ts
+++ b/src/services/member/utils.ts
@@ -11,17 +11,11 @@ export type UserRole = keyof typeof userRoles;
 export const role = (target: UserRole) => {
   const targetScore = userRoles[target];
   return {
-    hasHigherAuthority: (compare: UserRole) => {
+    hasHigherAuthorityThan: (compare: UserRole) => {
       return targetScore < userRoles[compare];
     },
-    hasHigherOrEqualAuthority: (compare: UserRole) => {
-      return targetScore <= userRoles[compare];
-    },
-    hasLowerAuthority: (compare: UserRole) => {
+    hasLowerAuthorityThan: (compare: UserRole) => {
       return targetScore > userRoles[compare];
-    },
-    hasLowerOrEqualAuthority: (compare: UserRole) => {
-      return targetScore >= userRoles[compare];
     },
   };
 };

--- a/src/services/member/utils.ts
+++ b/src/services/member/utils.ts
@@ -1,0 +1,27 @@
+/**
+ * 숫자가 낮을수록 높은 권한을 가집니다.
+ */
+const userRoles = {
+  admin: 1,
+  user: 2,
+};
+
+export type UserRole = keyof typeof userRoles;
+
+export const role = (target: UserRole) => {
+  const targetScore = userRoles[target];
+  return {
+    hasHigherAuthority: (compare: UserRole) => {
+      return targetScore < userRoles[compare];
+    },
+    hasHigherOrEqualAuthority: (compare: UserRole) => {
+      return targetScore <= userRoles[compare];
+    },
+    hasLowerAuthority: (compare: UserRole) => {
+      return targetScore > userRoles[compare];
+    },
+    hasLowerOrEqualAuthority: (compare: UserRole) => {
+      return targetScore >= userRoles[compare];
+    },
+  };
+};

--- a/src/types/next.d.ts
+++ b/src/types/next.d.ts
@@ -1,6 +1,7 @@
 import type { AppProps } from 'next/app';
 import type { NextPage, NextComponentType, NextPageContext } from 'next/types';
 import type { ReactElement } from 'react';
+import type { UserRole } from '~/services/member';
 
 type NextPageConfig = {
   auth: {
@@ -8,7 +9,7 @@ type NextPageConfig = {
      * - 페이지에 접근하기 위한 유저의 최소 권한입니다.
      * - 명시한 `role`보다 낮은 권한을 가진 유저는 페이지를 볼 수 없습니다.
      */
-    role: string;
+    role: UserRole;
     /**
      * - 유저 정보를 fetch하는 중에 보여줄 UI입니다.
      */

--- a/src/types/next.d.ts
+++ b/src/types/next.d.ts
@@ -1,0 +1,41 @@
+import type { AppProps } from 'next/app';
+import type { NextPage, NextComponentType, NextPageContext } from 'next/types';
+import type { ReactElement } from 'react';
+
+type NextPageConfig = {
+  auth: {
+    /**
+     * - 페이지에 접근하기 위한 유저의 최소 권한입니다.
+     * - 명시한 `role`보다 낮은 권한을 가진 유저는 페이지를 볼 수 없습니다.
+     */
+    role: string;
+    /**
+     * - 유저 정보를 fetch하는 중에 보여줄 UI입니다.
+     */
+    loading?: ReactElement;
+    /**
+     * - 권한이 없는 유저에게 보여줄 UI이거나, 리다이렉트 시킬 url입니다.
+     */
+    unauthorized: ReactElement | string;
+  };
+};
+
+declare module 'next/types' {
+  export type NextPageAuthConfig = NextPageConfig['auth'];
+
+  // eslint-disable-next-line
+  export type CustomNextPage<Props = {}, InitialProps = Props> = NextPage<
+    Props,
+    InitialProps
+  > &
+    Partial<NextPageConfig>;
+}
+
+declare module 'next/app' {
+  // eslint-disable-next-line
+  export type CustomAppProps<P = any> = AppProps<P> & {
+    // eslint-disable-next-line
+    Component: NextComponentType<NextPageContext, any, any> &
+      Partial<NextPageConfig>;
+  };
+}


### PR DESCRIPTION
## Issues

- #26 

<!-- 이슈 번호를 작성해주세요. 여러 이슈 번호를 작성해도 됩니다. -->

## 구분

- [ ] 버그 수정
- [x] 기능 추가
- [x] 코드 리팩터링
- [ ] 문서 업데이트
- [ ] 기타

<!-- 어떤 이유로 코드를 변경했는지 체크해주세요. -->

## 주요 변경점

- 구현 배경은 이슈 참고해주세요!
- `<AuthChecker />`구현
- Nextjs 내장 타입을 확장한 `CustomNextPage`, `CustomAppProps` 추가
- `CustomNextPage`는 페이지 컴포넌트에 사용하여, 페이지에 `auth`프로퍼티를 추가할 때 타입힌트를 제공합니다.
- `CustomAppProps`는 `_app.tsx`의 `<App />`컴포넌트에서 사용하여, 전달받은 페이지 컴포넌트에서 `auth`프로퍼티를 참조할 수 있게 해줍니다.

<!-- 주요 변경점과 어떤 부분을 집중해서 리뷰해야 하는지 알려주세요. -->

## 스크린샷


<!-- 관련 미디어 파일이 있으면 첨부해주세요. -->

## 기타

<!-- 추가로 전달할 내용, 메모할 내용, 테스트 계획, 완료된 테스트 등을 알려주세요. -->

