### PR TITLE
커스텀 에디터, 이미지 업로드

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "react-quill": "^2.0.0",
     "react-redux": "^8.0.5",
     "react-spinners": "^0.13.8",
+    "react-zoom-pan-pinch": "^3.1.0",
     "unique-names-generator": "^4.7.1"
   },
   "packageManager": "yarn@3.5.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@radix-ui/react-accessible-icon": "^1.0.3",
     "@radix-ui/react-dialog": "^1.0.4",
     "@radix-ui/react-select": "^1.2.2",
+    "@radix-ui/react-slider": "^1.1.2",
     "@radix-ui/react-slot": "^1.0.2",
     "@reduxjs/toolkit": "^1.9.5",
     "@tanstack/react-query": "^4.29.5",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "react-hook-form": "^7.45.0",
     "react-hot-toast": "^2.4.1",
     "react-icons": "^4.9.0",
+    "react-quill": "^2.0.0",
     "react-redux": "^8.0.5",
     "react-spinners": "^0.13.8",
     "unique-names-generator": "^4.7.1"

--- a/src/components/Common/Icon/index.tsx
+++ b/src/components/Common/Icon/index.tsx
@@ -3,6 +3,7 @@ import type { CSSProperties } from 'react';
 import { css } from '@emotion/react';
 import { AccessibleIcon } from '@radix-ui/react-accessible-icon';
 import { AiFillApple, AiFillGithub, AiOutlineGoogle } from 'react-icons/ai';
+import { BiImageAdd } from 'react-icons/bi';
 import { HiOutlineArrowLeft } from 'react-icons/hi';
 import { HiChatBubbleOvalLeftEllipsis } from 'react-icons/hi2';
 import { IoMdListBox } from 'react-icons/io';
@@ -71,6 +72,8 @@ export const icons = {
   share: <MdIosShare />,
 
   [`chevron.down`]: <MdKeyboardArrowDown />,
+
+  image: <BiImageAdd />,
 
   google: <AiOutlineGoogle />,
   github: <AiFillGithub />,

--- a/src/components/Common/Icon/index.tsx
+++ b/src/components/Common/Icon/index.tsx
@@ -4,7 +4,7 @@ import { css } from '@emotion/react';
 import { AccessibleIcon } from '@radix-ui/react-accessible-icon';
 import { AiFillApple, AiFillGithub, AiOutlineGoogle } from 'react-icons/ai';
 import { BiImageAdd } from 'react-icons/bi';
-import { HiOutlineArrowLeft } from 'react-icons/hi';
+import { HiMinus, HiOutlineArrowLeft, HiPlus } from 'react-icons/hi';
 import { HiChatBubbleOvalLeftEllipsis } from 'react-icons/hi2';
 import { IoMdListBox } from 'react-icons/io';
 import { IoTriangle } from 'react-icons/io5';
@@ -57,6 +57,8 @@ export const icons = {
 
   [`circle.plus`]: <MdControlPoint />,
   [`circle.minus`]: <MdRemoveCircleOutline />,
+  plus: <HiPlus />,
+  minus: <HiMinus />,
 
   notification: <MdNotifications />,
   more: <MdMoreVert />,

--- a/src/components/Common/SliderInput/index.tsx
+++ b/src/components/Common/SliderInput/index.tsx
@@ -1,0 +1,86 @@
+import { css } from '@emotion/react';
+import * as Slider from '@radix-ui/react-slider';
+
+import { flex, palettes } from '~/styles/utils';
+
+interface SliderInputProps {
+  value?: number[];
+  defaultValue?: number[];
+  min?: number;
+  max?: number;
+  step?: number;
+  onValueChange?: (value: number[]) => void;
+  className?: string;
+}
+
+const SliderInput = (props: SliderInputProps) => {
+  const {
+    className,
+    defaultValue,
+    value = undefined,
+    onValueChange,
+    step,
+    min,
+    max,
+  } = props;
+  return (
+    <Slider.Root
+      className={className}
+      onValueChange={onValueChange}
+      defaultValue={defaultValue}
+      value={value}
+      min={min}
+      max={max}
+      step={step}
+      css={selfCss}
+    >
+      <Slider.Track css={trackCss}>
+        <Slider.Range css={rangeCss} />
+      </Slider.Track>
+      <Slider.Thumb css={thumbCss} />
+    </Slider.Root>
+  );
+};
+
+export default SliderInput;
+
+const selfCss = css(
+  {
+    width: '100%',
+    height: '10px',
+    position: 'relative',
+    cursor: 'pointer',
+  },
+  flex('center', '', 'row')
+);
+
+const trackCss = css({
+  display: 'block',
+  position: 'relative',
+  backgroundColor: palettes.white,
+  width: '100%',
+  height: '2px',
+});
+
+const rangeCss = css({
+  position: 'absolute',
+  display: 'block',
+  backgroundColor: palettes.white,
+  height: '100%',
+});
+
+const thumbCss = css({
+  cursor: 'pointer',
+  display: 'block',
+  width: 20,
+  height: 20,
+  borderRadius: '50%',
+  position: 'absolute',
+  top: -10,
+  left: -10,
+  backgroundColor: palettes.white,
+  transition: 'transform 200ms',
+  ':focus': {
+    transform: 'scale(1.3, 1.3)',
+  },
+});

--- a/src/components/Common/SsafyIcon/Track.tsx
+++ b/src/components/Common/SsafyIcon/Track.tsx
@@ -10,8 +10,11 @@ import JavaTrack from '~/assets/images/track-java.svg';
 import MobileTrack from '~/assets/images/track-mobile.svg';
 import PythonTrack from '~/assets/images/track-python.svg';
 import Uncertified from '~/assets/images/track-uncertified.svg';
-import { MajorType } from '~/services/member';
+import { MajorType } from '~/services/member/utils';
 import { inlineFlex } from '~/styles/utils';
+
+// MajorType을 ~/services/member 에서 가져오면 참조 오류가 발생하는데 이유를 잘 모르겠습니다.
+// import 구문 옆에다 주석 달면 린트 오류가 발생해서 여기 적어둡니다.
 
 export interface TrackProps<Track extends keyof typeof tracks> {
   /**

--- a/src/components/Common/SsafyIcon/Track.tsx
+++ b/src/components/Common/SsafyIcon/Track.tsx
@@ -37,7 +37,7 @@ const Track = <T extends keyof typeof tracks>(props: TrackProps<T>) => {
   const TrackComponent = tracks[name];
 
   return (
-    <div css={selfCss} style={{ ...containerStyle }}>
+    <div css={selfCss}>
       <AccessibleIcon label={label}>
         <TrackComponent style={{ height: size, ...style }} theme={theme} />
       </AccessibleIcon>

--- a/src/components/Common/SsafyIcon/index.tsx
+++ b/src/components/Common/SsafyIcon/index.tsx
@@ -7,3 +7,4 @@ const SsafyIcon = {
 };
 
 export default SsafyIcon;
+export * from './Track';

--- a/src/components/Common/index.ts
+++ b/src/components/Common/index.ts
@@ -11,7 +11,10 @@ export { default as Logo } from './Logo';
 export { default as ProgressBar } from './ProgressBar';
 export { default as SelectBox } from './SelectBox';
 export { default as SkillStack } from './SkillStack';
+
 export { default as SsafyIcon } from './SsafyIcon';
+export * from './SsafyIcon';
+
 export { default as TextInput } from './TextInput';
 export { default as Modal } from './Modal';
 export { default as VisuallyHidden } from './VisuallyHidden';

--- a/src/components/Editor/Editor.stories.tsx
+++ b/src/components/Editor/Editor.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import Editor from './index';
+
+const meta: Meta<typeof Editor> = {
+  title: 'Editor',
+  component: Editor,
+};
+
+export default meta;
+
+type EditorStory = StoryObj<typeof Editor>;
+export const Default: EditorStory = {
+  args: {},
+};

--- a/src/components/Editor/Thumbnail.tsx
+++ b/src/components/Editor/Thumbnail.tsx
@@ -1,0 +1,53 @@
+import Image from 'next/image';
+
+import { css } from '@emotion/react';
+import { memo } from 'react';
+
+import { colorMix, inlineFlex, palettes } from '~/styles/utils';
+
+interface ThumbnailProps {
+  src: string;
+  alt: string;
+  size?: number;
+  onClick?: () => void;
+}
+
+const Thumbnail = (props: ThumbnailProps) => {
+  const { src, alt, size = defaultSize, onClick } = props;
+
+  return (
+    <div css={selfCss} style={{ width: size, height: size }} onClick={onClick}>
+      <Image css={imageCss} src={src} alt={alt} width={size} height={size} />
+    </div>
+  );
+};
+
+export default memo(Thumbnail);
+
+const defaultSize = 80;
+const selfCss = css(
+  {
+    position: 'relative',
+    borderRadius: 20,
+    width: defaultSize,
+    height: defaultSize,
+    overflow: 'hidden',
+    cursor: 'pointer',
+    '::after': {
+      transition: 'background-color 200ms',
+      position: 'absolute',
+      width: defaultSize,
+      height: defaultSize,
+      content: '""',
+      display: 'block',
+    },
+    ':hover': {
+      '::after': {
+        backgroundColor: colorMix('30%', palettes.black),
+      },
+    },
+  },
+  inlineFlex()
+);
+
+const imageCss = css({ objectFit: 'cover' });

--- a/src/components/Editor/Thumbnail.tsx
+++ b/src/components/Editor/Thumbnail.tsx
@@ -3,51 +3,94 @@ import Image from 'next/image';
 import { css } from '@emotion/react';
 import { memo } from 'react';
 
+import { Icon } from '~/components/Common';
 import { colorMix, inlineFlex, palettes } from '~/styles/utils';
 
 interface ThumbnailProps {
   src: string;
   alt: string;
   size?: number;
-  onClick?: () => void;
+  onClickThumbnail?: () => void;
+  onClickRemove?: () => void;
 }
 
 const Thumbnail = (props: ThumbnailProps) => {
-  const { src, alt, size = defaultSize, onClick } = props;
+  const {
+    src,
+    alt,
+    size = defaultSize,
+    onClickThumbnail,
+    onClickRemove,
+  } = props;
 
   return (
-    <div css={selfCss} style={{ width: size, height: size }} onClick={onClick}>
-      <Image css={imageCss} src={src} alt={alt} width={size} height={size} />
-    </div>
+    <li css={selfCss}>
+      <div
+        css={imageContainerCss}
+        style={{ width: size, height: size }}
+        onClick={onClickThumbnail}
+        data-thumbnail=""
+      >
+        <Image css={imageCss} src={src} alt={alt} width={size} height={size} />
+      </div>
+      <button type="button" css={removeButtonCss} onClick={onClickRemove}>
+        <Icon name="close" size={12} label="썸네일 삭제" />
+      </button>
+    </li>
   );
 };
 
 export default memo(Thumbnail);
 
-const defaultSize = 80;
+const defaultSize = 70;
 const selfCss = css(
   {
     position: 'relative',
-    borderRadius: 20,
-    width: defaultSize,
-    height: defaultSize,
-    overflow: 'hidden',
-    cursor: 'pointer',
-    '::after': {
-      transition: 'background-color 200ms',
-      position: 'absolute',
-      width: defaultSize,
-      height: defaultSize,
-      content: '""',
-      display: 'block',
-    },
     ':hover': {
-      '::after': {
+      '& [data-thumbnail]::after': {
         backgroundColor: colorMix('30%', palettes.black),
       },
     },
   },
-  inlineFlex()
+  inlineFlex('center', 'center')
+);
+
+const imageContainerCss = css(
+  {
+    width: defaultSize,
+    height: defaultSize,
+    position: 'relative',
+    cursor: 'pointer',
+    overflow: 'hidden',
+    borderRadius: 20,
+    '::after': {
+      transition: 'background-color 200ms',
+      position: 'absolute',
+      width: '100%',
+      height: '100%',
+      content: '""',
+      display: 'block',
+    },
+  },
+  inlineFlex('center', 'center')
 );
 
 const imageCss = css({ objectFit: 'cover' });
+
+const removeButtonCss = css(
+  {
+    cursor: 'pointer',
+    width: 20,
+    height: 20,
+    position: 'absolute',
+    backgroundColor: palettes.grey4,
+    borderRadius: '50%',
+    top: -5,
+    right: -5,
+    border: `1px solid ${palettes.black}`,
+    ':hover': {
+      backgroundColor: palettes.white,
+    },
+  },
+  inlineFlex('center', 'center')
+);

--- a/src/components/Editor/ThumbnailBar.tsx
+++ b/src/components/Editor/ThumbnailBar.tsx
@@ -1,0 +1,51 @@
+import { css } from '@emotion/react';
+import { useState } from 'react';
+
+import { Modal } from '~/components/Common';
+import Thumbnail from '~/components/Editor/Thumbnail';
+import { flex } from '~/styles/utils';
+
+interface ThumbnailBarProps {
+  thumbnails: string[];
+}
+
+const ThumbnailBar = (props: ThumbnailBarProps) => {
+  const { thumbnails } = props;
+  const [open, setOpen] = useState(false);
+  const closeModal = () => setOpen(false);
+  const openModal = () => setOpen(true);
+  return (
+    <>
+      <ol css={selfCss}>
+        {thumbnails.map((thumbnail) => (
+          <Thumbnail
+            key={thumbnail}
+            src={thumbnail}
+            alt=""
+            size={70}
+            onClickThumbnail={openModal}
+            onClickRemove={() => {
+              console.log('remove clicked');
+            }}
+          />
+        ))}
+      </ol>
+      <Modal
+        content={<></>}
+        open={open}
+        onPointerDownOutside={closeModal}
+        onEscapeKeyDown={closeModal}
+      />
+    </>
+  );
+};
+
+export default ThumbnailBar;
+
+const selfCss = css(
+  {
+    width: '100%',
+    padding: 10,
+  },
+  flex('', '', 'row', 10, 'wrap')
+);

--- a/src/components/Editor/ThumbnailBar.tsx
+++ b/src/components/Editor/ThumbnailBar.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { useEffect, useState } from 'react';
+import { memo, useState } from 'react';
 
 import { Icon, IconButton, Modal } from '~/components/Common';
 import Thumbnail from '~/components/Editor/Thumbnail';
@@ -82,7 +82,7 @@ const ThumbnailBar = (props: ThumbnailBarProps) => {
   );
 };
 
-export default ThumbnailBar;
+export default memo(ThumbnailBar);
 
 const selfCss = css(
   {

--- a/src/components/Editor/ThumbnailBar.tsx
+++ b/src/components/Editor/ThumbnailBar.tsx
@@ -1,8 +1,9 @@
 import { css } from '@emotion/react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
-import { Modal } from '~/components/Common';
+import { Icon, IconButton, Modal } from '~/components/Common';
 import Thumbnail from '~/components/Editor/Thumbnail';
+import { ImageViewer } from '~/components/ModalContent';
 import { flex } from '~/styles/utils';
 
 interface ThumbnailBarProps {
@@ -14,28 +15,69 @@ const ThumbnailBar = (props: ThumbnailBarProps) => {
   const [open, setOpen] = useState(false);
   const closeModal = () => setOpen(false);
   const openModal = () => setOpen(true);
+
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const lastIndex = thumbnails.length - 1;
+  const hasThumbnail = !!thumbnails.length;
+
   return (
     <>
       <ol css={selfCss}>
-        {thumbnails.map((thumbnail) => (
+        {thumbnails.map((thumbnail, index) => (
           <Thumbnail
             key={thumbnail}
             src={thumbnail}
             alt=""
             size={70}
-            onClickThumbnail={openModal}
-            onClickRemove={() => {
-              console.log('remove clicked');
+            onClickThumbnail={() => {
+              openModal();
+              setSelectedIndex(index);
             }}
+            onClickRemove={() => console.log('remove clicked')}
           />
         ))}
       </ol>
-      <Modal
-        content={<></>}
-        open={open}
-        onPointerDownOutside={closeModal}
-        onEscapeKeyDown={closeModal}
-      />
+      {hasThumbnail && (
+        <Modal
+          open={open}
+          onPointerDownOutside={closeModal}
+          onEscapeKeyDown={closeModal}
+          content={
+            <ImageViewer
+              src={thumbnails[selectedIndex]}
+              onClickClose={closeModal}
+              controlButtons={
+                <div css={controlButtonsCss}>
+                  <IconButton
+                    size={34}
+                    onClick={() => setSelectedIndex((p) => p - 1)}
+                    disabled={selectedIndex === 0}
+                  >
+                    <Icon
+                      size={34}
+                      name="chevron.down"
+                      label="이전 썸네일"
+                      style={{ transform: 'rotate(90deg)' }}
+                    />
+                  </IconButton>
+                  <IconButton
+                    size={34}
+                    onClick={() => setSelectedIndex((p) => p + 1)}
+                    disabled={selectedIndex === lastIndex}
+                  >
+                    <Icon
+                      size={34}
+                      name="chevron.down"
+                      label="다음 썸네일"
+                      style={{ transform: 'rotate(-90deg)' }}
+                    />
+                  </IconButton>
+                </div>
+              }
+            />
+          }
+        />
+      )}
     </>
   );
 };
@@ -49,3 +91,5 @@ const selfCss = css(
   },
   flex('', '', 'row', 10, 'wrap')
 );
+
+const controlButtonsCss = css(flex('', '', 'row', 10));

--- a/src/components/Editor/imageHandler.ts
+++ b/src/components/Editor/imageHandler.ts
@@ -1,0 +1,58 @@
+import { toWebp, MB, byteToMB } from '~/utils/toWebp';
+
+const LIMIT_FILE_SIZE = MB * 10; /* byte */
+const ACCEPTS = 'image/webp, image/png, image/jpeg, image/jpg, image/gif';
+const QUALITY = 0.5;
+
+export interface ImageHandlerOptions {
+  onUploadStart: () => void;
+  onUploadSuccess: (imageValues: Awaited<ReturnType<typeof toWebp>>) => void;
+  onUploadError: (reason: string) => void;
+  onUploadSettled: () => void;
+}
+
+export type ImageHandler = (options?: Partial<ImageHandlerOptions>) => void;
+
+export const imageHandler: ImageHandler = (options = {}) => {
+  const $input = document.createElement('input');
+  $input.setAttribute('type', 'file');
+  $input.setAttribute('accept', ACCEPTS);
+  $input.click();
+  $input.addEventListener('change', handleUploadImage(options));
+};
+
+type HandleUploadImage = (
+  options?: Partial<ImageHandlerOptions>
+) => (e: Event) => void;
+
+const handleUploadImage: HandleUploadImage =
+  (options = {}) =>
+  (e) => {
+    const { onUploadStart, onUploadSuccess, onUploadSettled, onUploadError } =
+      options;
+
+    const $target = e.target as HTMLInputElement;
+    if (!$target.files) return;
+
+    onUploadStart?.(); // upload 시작
+    const file = $target.files[0];
+    const fileSize = file.size;
+
+    if (fileSize > LIMIT_FILE_SIZE) {
+      onUploadError?.(
+        `파일 크기는 ${byteToMB(fileSize)}MB 보다 작아야 합니다.`
+      );
+      return;
+    }
+
+    toWebp(file, { maxWebpSize: LIMIT_FILE_SIZE, quality: QUALITY })
+      .then((data) => onUploadSuccess?.(data))
+      .catch((e: unknown) => {
+        if (typeof e === 'string') {
+          onUploadError?.(e);
+          return;
+        }
+        console.error('Unknown Error', e);
+      })
+      .finally(() => onUploadSettled?.());
+  };

--- a/src/components/Editor/index.tsx
+++ b/src/components/Editor/index.tsx
@@ -1,0 +1,115 @@
+import dynamic from 'next/dynamic';
+import Image from 'next/image';
+
+import { css } from '@emotion/react';
+import { useCallback, useMemo, useState } from 'react';
+import 'react-quill/dist/quill.snow.css';
+
+import { Icon, IconButton } from '~/components/Common';
+import { fontCss, palettes } from '~/styles/utils';
+
+
+const ReactQuill = dynamic(import('react-quill'), {
+  ssr: false,
+  loading: () => <p>Loading</p>,
+});
+
+interface EditorProps {}
+
+const Editor = (props: EditorProps) => {
+  const [value, setValue] = useState('');
+  const [thumbnails, setThumbnails] = useState([]);
+
+  const handleClickImageUpload = useCallback(() => {},[])
+
+  const toolbar = useMemo(() => {
+    return {
+      container: [
+        [{ header: [1, 2, 3, false] }],
+        ['bold', 'underline'],
+        [{ list: 'ordered' }, { list: 'bullet' }],
+        ['link'],
+        ['clean'],
+      ],
+      handlers: {
+        image: handleClickImageUpload,
+      },
+    };
+  }, [handleClickImageUpload]);
+
+  const formats = useMemo(
+    () => ['header', 'bold', 'underline', 'ordered', 'bullet', 'link'],
+    []
+  );
+
+  return (
+    <div css={selfCss}>
+      <ReactQuill
+        css={{
+          fontFamily: `${fontCss.family.auto.fontFamily} !important`,
+        }}
+        modules={{
+          toolbar,
+        }}
+        value={value}
+        onChange={setValue}
+        placeholder={'placeholder'}
+        formats={formats}
+      />
+      <div>
+        <div>
+          {thumbnails.map((thumbnail) => {
+            return (
+              <Image
+                key={thumbnail}
+                src={thumbnail}
+                alt=""
+                width={400}
+                height={400}
+                style={{ objectFit: 'cover' }}
+              />
+            );
+          })}
+        </div>
+        <div css={thumbnailBarCss}></div>
+        <div css={bottomToolbarCss}>
+          <IconButton type="button" size={28} theme="black">
+            <Icon name="image" label="사진 첨부" size={18} />
+          </IconButton>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Editor;
+
+const editorContainerSelector = '.ql-container';
+const editorSelector = '.ql-editor';
+const editorBorder = '0.571429px rgb(204, 204, 204) solid';
+
+const selfCss = css({
+  backgroundColor: palettes.white,
+  color: 'black',
+  [`& ${editorContainerSelector}`]: {
+    borderBottom: 0,
+  },
+  [`& ${editorSelector}`]: {
+    fontFamily: fontCss.family.auto.fontFamily,
+    height: 300,
+    '::before': {
+      // placeholder 스타일
+      fontStyle: 'normal',
+    },
+  },
+  '& strong': {
+    fontWeight: 700,
+  },
+});
+
+const thumbnailBarCss = css({});
+
+const bottomToolbarCss = css({
+  padding: 8,
+  border: editorBorder,
+});

--- a/src/components/Editor/index.tsx
+++ b/src/components/Editor/index.tsx
@@ -1,86 +1,95 @@
 import dynamic from 'next/dynamic';
-import Image from 'next/image';
 
 import { css } from '@emotion/react';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useState } from 'react';
 import 'react-quill/dist/quill.snow.css';
 
 import { Icon, IconButton } from '~/components/Common';
+import ThumbnailBar from '~/components/Editor/ThumbnailBar';
 import { fontCss, palettes } from '~/styles/utils';
 
+import { imageHandler } from './imageHandler';
 
 const ReactQuill = dynamic(import('react-quill'), {
   ssr: false,
-  loading: () => <p>Loading</p>,
+  loading: () => <p>로딩중</p>,
 });
 
 interface EditorProps {}
 
 const Editor = (props: EditorProps) => {
   const [value, setValue] = useState('');
-  const [thumbnails, setThumbnails] = useState([]);
+  const [images, setImages] = useState<Blob[]>([]);
+  const [thumbnails, setThumbnails] = useState<string[]>([]);
 
-  const handleClickImageUpload = useCallback(() => {},[])
-
-  const toolbar = useMemo(() => {
-    return {
-      container: [
-        [{ header: [1, 2, 3, false] }],
-        ['bold', 'underline'],
-        [{ list: 'ordered' }, { list: 'bullet' }],
-        ['link'],
-        ['clean'],
-      ],
-      handlers: {
-        image: handleClickImageUpload,
+  const handleImageUpload = useCallback(() => {
+    imageHandler({
+      onUploadStart: () => {
+        /* loading true */
       },
-    };
-  }, [handleClickImageUpload]);
-
-  const formats = useMemo(
-    () => ['header', 'bold', 'underline', 'ordered', 'bullet', 'link'],
-    []
-  );
+      onUploadSettled: () => {
+        /* loading false */
+      },
+      onUploadError: (err) => console.log(err),
+      onUploadSuccess: ({ blob, src }) => {
+        // NOTE: s3에 즉시 업로드하는 방식이 될 듯
+        setImages((prevBlobs) => [...prevBlobs, blob]);
+        setThumbnails((prevThumbnails) => [...prevThumbnails, src]);
+      },
+    });
+  }, []);
 
   return (
     <div css={selfCss}>
       <ReactQuill
-        css={{
-          fontFamily: `${fontCss.family.auto.fontFamily} !important`,
-        }}
-        modules={{
-          toolbar,
-        }}
+        modules={modules}
         value={value}
         onChange={setValue}
         placeholder={'placeholder'}
         formats={formats}
       />
-      <div>
-        <div>
-          {thumbnails.map((thumbnail) => {
-            return (
-              <Image
-                key={thumbnail}
-                src={thumbnail}
-                alt=""
-                width={400}
-                height={400}
-                style={{ objectFit: 'cover' }}
-              />
-            );
-          })}
-        </div>
-        <div css={thumbnailBarCss}></div>
-        <div css={bottomToolbarCss}>
-          <IconButton type="button" size={28} theme="black">
-            <Icon name="image" label="사진 첨부" size={18} />
-          </IconButton>
-        </div>
+
+      <div css={thumbnailBarCss}>
+        <ThumbnailBar thumbnails={thumbnails} />
+      </div>
+
+      <div css={bottomToolbarCss}>
+        <IconButton
+          type="button"
+          size={28}
+          theme="black"
+          onClick={handleImageUpload}
+        >
+          <Icon name="image" label="사진 첨부" size={18} />
+        </IconButton>
       </div>
     </div>
   );
 };
+
+const modules = {
+  toolbar: {
+    container: [
+      [{ header: [1, 2, 3, false] }],
+      ['bold', 'underline'],
+      ['code', 'code-block'],
+      [{ list: 'ordered' }, { list: 'bullet' }],
+      ['link'],
+      ['clean'],
+    ],
+  },
+};
+
+const formats = [
+  'header',
+  'bold',
+  'underline',
+  'ordered',
+  'bullet',
+  'link',
+  'code',
+  'code-block',
+];
 
 export default Editor;
 

--- a/src/components/ModalContent/ImageViewer/ImageLayer.tsx
+++ b/src/components/ModalContent/ImageViewer/ImageLayer.tsx
@@ -1,0 +1,93 @@
+import type { ReactZoomPanPinchHandlers } from 'react-zoom-pan-pinch';
+
+import { css } from '@emotion/react';
+import { useLayoutEffect, useRef } from 'react';
+import { TransformComponent } from 'react-zoom-pan-pinch';
+
+import { flex } from '~/styles/utils';
+
+export interface ImageLayerProps {
+  src: string;
+  alt?: string;
+  transformHandlers: ReactZoomPanPinchHandlers;
+  onResizeWindow: (scale: number) => void;
+}
+
+const transformerClassname = 'image-transformer';
+
+const ImageLayer = (props: ImageLayerProps) => {
+  const { src, alt = '', transformHandlers, onResizeWindow } = props;
+  const imageRef = useRef<HTMLImageElement>(null);
+  const imageContainerRef = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    if (!imageRef.current || !imageContainerRef.current) return;
+
+    const onResize = handleResize(imageRef.current, imageContainerRef.current, {
+      scaleFactor: 0.5,
+      onCalculateScale: (scale) => {
+        transformHandlers.centerView(scale, 0);
+        onResizeWindow(scale);
+      },
+    });
+
+    onResize();
+
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  }, [src, transformHandlers, onResizeWindow]);
+
+  return (
+    <div css={imageContainerCss} ref={imageContainerRef}>
+      <TransformComponent wrapperClass={transformerClassname}>
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img src={src} alt={alt} ref={imageRef} />
+      </TransformComponent>
+    </div>
+  );
+};
+
+interface HandleResizeOptions {
+  /** `scale`계산 이후 호출할 콜백함수 */
+  onCalculateScale: (scale: number) => void;
+  /** 계산된 `scale`에 곱할 상수 */
+  scaleFactor: number;
+}
+
+type HandleResize = (
+  target: HTMLImageElement,
+  container: HTMLElement,
+  options?: Partial<HandleResizeOptions>
+) => (e?: UIEvent) => void;
+
+const handleResize: HandleResize =
+  (target, container, options = {}) =>
+  () => {
+    const { onCalculateScale, scaleFactor = 1 } = options;
+    const containerWidth = container.offsetWidth;
+    const containerHeight = container.offsetHeight;
+    const scaleX = containerWidth / target.naturalWidth;
+    const scaleY = containerHeight / target.naturalHeight;
+    const scale = Math.min(scaleX, scaleY) * scaleFactor;
+
+    onCalculateScale?.(scale);
+  };
+
+export default ImageLayer;
+
+const imageContainerCss = css(
+  {
+    width: '100%',
+    height: '100%',
+    overflow: 'hidden',
+    [`& .${transformerClassname}`]: {
+      userSelect: 'none',
+      width: '100%',
+      height: '100%',
+      ':active': {
+        cursor: 'grabbing',
+      },
+    },
+  },
+  flex('center', 'center', 'row')
+);

--- a/src/components/ModalContent/ImageViewer/ViewerHeader.tsx
+++ b/src/components/ModalContent/ImageViewer/ViewerHeader.tsx
@@ -1,0 +1,32 @@
+import { css } from '@emotion/react';
+
+import { Icon, IconButton, Modal } from '~/components/Common';
+import { flex, palettes } from '~/styles/utils';
+
+export interface ViewerHeaderProps {
+  onClickClose?: () => void;
+}
+
+const ViewerHeader = (props: ViewerHeaderProps) => {
+  const { onClickClose } = props;
+  return (
+    <div css={selfCss}>
+      <Modal.Close asChild>
+        <IconButton size={34} onClick={onClickClose}>
+          <Icon name="close" size={28} />
+        </IconButton>
+      </Modal.Close>
+    </div>
+  );
+};
+
+export default ViewerHeader;
+
+const selfCss = css(
+  {
+    flexGrow: 1,
+    padding: '0 15px',
+    borderBottom: `1px solid ${palettes.grey1}`,
+  },
+  flex('center', 'flex-end', 'row')
+);

--- a/src/components/ModalContent/ImageViewer/ViewerHeader.tsx
+++ b/src/components/ModalContent/ImageViewer/ViewerHeader.tsx
@@ -1,3 +1,5 @@
+import type { ReactNode } from 'react';
+
 import { css } from '@emotion/react';
 
 import { Icon, IconButton, Modal } from '~/components/Common';
@@ -5,12 +7,17 @@ import { flex, palettes } from '~/styles/utils';
 
 export interface ViewerHeaderProps {
   onClickClose?: () => void;
+  controlButtons?: ReactNode;
 }
 
 const ViewerHeader = (props: ViewerHeaderProps) => {
-  const { onClickClose } = props;
+  const { onClickClose, controlButtons } = props;
+  const hasAdditionalButtons = !!controlButtons;
+
   return (
-    <div css={selfCss}>
+    <div css={[selfCss, hasAdditionalButtons && betweenCss]}>
+      {controlButtons}
+
       <Modal.Close asChild>
         <IconButton size={34} onClick={onClickClose}>
           <Icon name="close" size={28} />
@@ -30,3 +37,7 @@ const selfCss = css(
   },
   flex('center', 'flex-end', 'row')
 );
+
+const betweenCss = css({
+  justifyContent: 'space-between',
+});

--- a/src/components/ModalContent/ImageViewer/ViewerMain.tsx
+++ b/src/components/ModalContent/ImageViewer/ViewerMain.tsx
@@ -1,0 +1,95 @@
+import { css } from '@emotion/react';
+import { useCallback, useState } from 'react';
+import { TransformWrapper } from 'react-zoom-pan-pinch';
+
+import { Icon, IconButton } from '~/components/Common';
+import { colorMix, flex, palettes, position } from '~/styles/utils';
+
+import ImageLayer from './ImageLayer';
+
+export interface ViewerMainProps {
+  src: string;
+  alt?: string;
+}
+
+const ViewerMain = (props: ViewerMainProps) => {
+  const { src, alt = '' } = props;
+  const [minScale, setMinScale] = useState(0.1);
+  const maxScale = 2;
+  const scaleStep = 0.4;
+
+  const onResizeWindow = useCallback((scale: number) => setMinScale(scale), []);
+
+  return (
+    <TransformWrapper
+      initialScale={minScale}
+      maxScale={maxScale}
+      minScale={minScale}
+      wheel={{ disabled: true }}
+      doubleClick={{ disabled: true }}
+      centerOnInit={true}
+      limitToBounds={false}
+    >
+      {(transformHandlers) => {
+        const { zoomIn, zoomOut, centerView } = transformHandlers;
+
+        return (
+          <>
+            <div css={viewerMainCss}>
+              <ImageLayer
+                src={src}
+                alt={alt}
+                transformHandlers={transformHandlers}
+                onResizeWindow={onResizeWindow}
+              />
+            </div>
+
+            <div css={viewerToolbarCss}>
+              <IconButton
+                size={iconButtonSize}
+                onClick={() => zoomOut(scaleStep, 100)}
+              >
+                <Icon name="minus" size={iconSize} />
+              </IconButton>
+
+              <IconButton
+                size={iconButtonSize}
+                onClick={() => zoomIn(scaleStep, 100)}
+              >
+                <Icon name="plus" size={iconSize} />
+              </IconButton>
+
+              <IconButton
+                size={iconButtonSize}
+                onClick={() => centerView(minScale)}
+              >
+                <Icon name="refresh" size={iconSize} />
+              </IconButton>
+            </div>
+          </>
+        );
+      }}
+    </TransformWrapper>
+  );
+};
+
+export default ViewerMain;
+
+const iconButtonSize = 34;
+const iconSize = 28;
+
+const viewerToolbarCss = css(
+  {
+    overflow: 'hidden',
+    bottom: 10,
+    padding: 10,
+    backgroundColor: colorMix('70%', palettes.grey0),
+    borderRadius: 24,
+  },
+  flex('center', 'center', 'row', 10),
+  position.x('center', 'absolute')
+);
+
+const viewerMainCss = css({
+  height: '92%',
+});

--- a/src/components/ModalContent/ImageViewer/index.tsx
+++ b/src/components/ModalContent/ImageViewer/index.tsx
@@ -1,104 +1,25 @@
-import { css } from '@emotion/react';
-import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import type { ViewerMainProps } from './ViewerMain';
+import type { ViewerHeaderProps } from '~/components/ModalContent/ImageViewer/ViewerHeader';
 
-import { Icon, IconButton, Modal } from '~/components/Common';
+import { css } from '@emotion/react';
+
 import { flex, palettes } from '~/styles/utils';
 
-interface ImageViewerProps {
-  src: string;
-  alt?: string;
-  onClickClose?: () => void;
-}
+import ViewerHeader from './ViewerHeader';
+import ViewerMain from './ViewerMain';
+
+interface ImageViewerProps extends ViewerHeaderProps, ViewerMainProps {}
 
 const ImageViewer = (props: ImageViewerProps) => {
-  const { src, alt = '', onClickClose } = props;
-  const [currentScale, setCurrentScale] = useState<number>();
-  const [optimizedScale, setOptimizedScale] = useState<number>();
-  const hasScale = !!currentScale;
-
-  const imageRef = useRef<HTMLImageElement>(null);
-  const imageContainerRef = useRef<HTMLImageElement>(null);
-
-  useLayoutEffect(() => {
-    if (!imageRef.current || !imageContainerRef.current) return;
-    imageRef.current.width = imageRef.current.naturalWidth;
-    imageRef.current.height = imageRef.current.naturalHeight;
-
-    const onResize = handleResize(imageRef.current, imageContainerRef.current, {
-      onCalculateScale: (scale) => {
-        setCurrentScale(scale);
-        setOptimizedScale(scale);
-      },
-      scaleFactor: 0.5,
-    });
-
-    onResize();
-    window.addEventListener('resize', onResize);
-    return () => window.removeEventListener('resize', onResize);
-  }, [src]);
-
-  useEffect(() => {
-    if (!imageRef.current) return;
-    const $image = imageRef.current;
-    setTimeout(() => {
-      $image.style.transition = `transform 200ms`;
-    }, 500);
-  }, [hasScale]);
+  const { src, alt, onClickClose } = props;
 
   return (
     <div css={selfCss}>
-      <div css={viewerHeaderCss}>
-        <Modal.Close asChild>
-          <IconButton size={34} onClick={onClickClose}>
-            <Icon name="close" size={28} />
-          </IconButton>
-        </Modal.Close>
-      </div>
-      <div css={viewerMainCss}>
-        <div css={imageContainerCss} ref={imageContainerRef}>
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
-            draggable={false}
-            css={imageCss}
-            src={src}
-            alt={alt}
-            ref={imageRef}
-            style={{
-              transform: `scale(${currentScale}, ${currentScale})`,
-            }}
-          />
-        </div>
-      </div>
-      <div css={viewerFooterCss}>d</div>
+      <ViewerHeader onClickClose={onClickClose} />
+      <ViewerMain src={src} alt={alt} />
     </div>
   );
 };
-
-interface HandleResizeOptions {
-  /** `scale`계산 이후 호출할 콜백함수 */
-  onCalculateScale: (scale: number) => void;
-  /** 계산된 `scale`에 곱할 상수 */
-  scaleFactor: number;
-}
-
-type HandleResize = (
-  target: HTMLImageElement,
-  container: HTMLElement,
-  options?: Partial<HandleResizeOptions>
-) => (e?: UIEvent) => void;
-
-const handleResize: HandleResize =
-  (target, container, options = {}) =>
-  () => {
-    const { onCalculateScale, scaleFactor = 1 } = options;
-    const containerWidth = container.offsetWidth;
-    const containerHeight = container.offsetHeight;
-    const scaleX = containerWidth / target.naturalWidth;
-    const scaleY = containerHeight / target.naturalHeight;
-    const scale = Math.min(scaleX, scaleY) * scaleFactor;
-
-    onCalculateScale?.(scale);
-  };
 
 export default ImageViewer;
 
@@ -108,41 +29,7 @@ const selfCss = css(
     inset: 30,
     backgroundColor: palettes.grey0,
     border: `1px solid ${palettes.grey1}`,
-    borderRadius: 16,
+    borderRadius: 8,
   },
   flex('', '')
 );
-
-const viewerHeaderCss = css(
-  {
-    flexGrow: 1,
-    padding: '0 10px',
-    borderBottom: `1px solid ${palettes.grey1}`,
-  },
-  flex('center', 'flex-end', 'row')
-);
-
-const viewerFooterCss = css(
-  {
-    flexGrow: 2,
-  },
-  flex('center', '', 'row')
-);
-
-const viewerMainCss = css({
-  height: '90%',
-  padding: '40px 20px',
-});
-
-const imageContainerCss = css(
-  {
-    width: '100%',
-    height: '100%',
-    overflow: 'hidden',
-  },
-  flex('center', 'center', 'row')
-);
-
-const imageCss = css({
-  userSelect: 'none',
-});

--- a/src/components/ModalContent/ImageViewer/index.tsx
+++ b/src/components/ModalContent/ImageViewer/index.tsx
@@ -11,11 +11,11 @@ import ViewerMain from './ViewerMain';
 interface ImageViewerProps extends ViewerHeaderProps, ViewerMainProps {}
 
 const ImageViewer = (props: ImageViewerProps) => {
-  const { src, alt, onClickClose } = props;
+  const { src, alt, ...viewerHeaderProps } = props;
 
   return (
     <div css={selfCss}>
-      <ViewerHeader onClickClose={onClickClose} />
+      <ViewerHeader {...viewerHeaderProps} />
       <ViewerMain src={src} alt={alt} />
     </div>
   );

--- a/src/components/ModalContent/ImageViewer/index.tsx
+++ b/src/components/ModalContent/ImageViewer/index.tsx
@@ -1,0 +1,148 @@
+import { css } from '@emotion/react';
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+
+import { Icon, IconButton, Modal } from '~/components/Common';
+import { flex, palettes } from '~/styles/utils';
+
+interface ImageViewerProps {
+  src: string;
+  alt?: string;
+  onClickClose?: () => void;
+}
+
+const ImageViewer = (props: ImageViewerProps) => {
+  const { src, alt = '', onClickClose } = props;
+  const [currentScale, setCurrentScale] = useState<number>();
+  const [optimizedScale, setOptimizedScale] = useState<number>();
+  const hasScale = !!currentScale;
+
+  const imageRef = useRef<HTMLImageElement>(null);
+  const imageContainerRef = useRef<HTMLImageElement>(null);
+
+  useLayoutEffect(() => {
+    if (!imageRef.current || !imageContainerRef.current) return;
+    imageRef.current.width = imageRef.current.naturalWidth;
+    imageRef.current.height = imageRef.current.naturalHeight;
+
+    const onResize = handleResize(imageRef.current, imageContainerRef.current, {
+      onCalculateScale: (scale) => {
+        setCurrentScale(scale);
+        setOptimizedScale(scale);
+      },
+      scaleFactor: 0.5,
+    });
+
+    onResize();
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  }, [src]);
+
+  useEffect(() => {
+    if (!imageRef.current) return;
+    const $image = imageRef.current;
+    setTimeout(() => {
+      $image.style.transition = `transform 200ms`;
+    }, 500);
+  }, [hasScale]);
+
+  return (
+    <div css={selfCss}>
+      <div css={viewerHeaderCss}>
+        <Modal.Close asChild>
+          <IconButton size={34} onClick={onClickClose}>
+            <Icon name="close" size={28} />
+          </IconButton>
+        </Modal.Close>
+      </div>
+      <div css={viewerMainCss}>
+        <div css={imageContainerCss} ref={imageContainerRef}>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            draggable={false}
+            css={imageCss}
+            src={src}
+            alt={alt}
+            ref={imageRef}
+            style={{
+              transform: `scale(${currentScale}, ${currentScale})`,
+            }}
+          />
+        </div>
+      </div>
+      <div css={viewerFooterCss}>d</div>
+    </div>
+  );
+};
+
+interface HandleResizeOptions {
+  /** `scale`계산 이후 호출할 콜백함수 */
+  onCalculateScale: (scale: number) => void;
+  /** 계산된 `scale`에 곱할 상수 */
+  scaleFactor: number;
+}
+
+type HandleResize = (
+  target: HTMLImageElement,
+  container: HTMLElement,
+  options?: Partial<HandleResizeOptions>
+) => (e?: UIEvent) => void;
+
+const handleResize: HandleResize =
+  (target, container, options = {}) =>
+  () => {
+    const { onCalculateScale, scaleFactor = 1 } = options;
+    const containerWidth = container.offsetWidth;
+    const containerHeight = container.offsetHeight;
+    const scaleX = containerWidth / target.naturalWidth;
+    const scaleY = containerHeight / target.naturalHeight;
+    const scale = Math.min(scaleX, scaleY) * scaleFactor;
+
+    onCalculateScale?.(scale);
+  };
+
+export default ImageViewer;
+
+const selfCss = css(
+  {
+    position: 'fixed',
+    inset: 30,
+    backgroundColor: palettes.grey0,
+    border: `1px solid ${palettes.grey1}`,
+    borderRadius: 16,
+  },
+  flex('', '')
+);
+
+const viewerHeaderCss = css(
+  {
+    flexGrow: 1,
+    padding: '0 10px',
+    borderBottom: `1px solid ${palettes.grey1}`,
+  },
+  flex('center', 'flex-end', 'row')
+);
+
+const viewerFooterCss = css(
+  {
+    flexGrow: 2,
+  },
+  flex('center', '', 'row')
+);
+
+const viewerMainCss = css({
+  height: '90%',
+  padding: '40px 20px',
+});
+
+const imageContainerCss = css(
+  {
+    width: '100%',
+    height: '100%',
+    overflow: 'hidden',
+  },
+  flex('center', 'center', 'row')
+);
+
+const imageCss = css({
+  userSelect: 'none',
+});

--- a/src/components/ModalContent/index.ts
+++ b/src/components/ModalContent/index.ts
@@ -1,2 +1,3 @@
 export { default as Alert } from './Alert';
 export { default as BottomMenu } from './BottomMenu';
+export { default as ImageViewer } from './ImageViewer';

--- a/src/components/UserRegisterForm/Fields/IsMember.tsx
+++ b/src/components/UserRegisterForm/Fields/IsMember.tsx
@@ -1,8 +1,7 @@
 import { css } from '@emotion/react';
 import { isBoolean } from 'is-what';
 
-import { Button, SsafyIcon } from '~/components/Common';
-import { TrackSize } from '~/components/Common/SsafyIcon/Track';
+import { Button, SsafyIcon, TrackSize } from '~/components/Common';
 import { useUpdateMyInfoFormContext } from '~/services/member';
 import { flex } from '~/styles/utils';
 

--- a/src/components/UserRegisterForm/context/index.tsx
+++ b/src/components/UserRegisterForm/context/index.tsx
@@ -1,15 +1,8 @@
-import type { Dispatch, FC, ReactNode, SetStateAction } from 'react';
+import type { FC, ReactNode } from 'react';
 
-import {
-  createContext,
-  useCallback,
-  useContext,
-  useMemo,
-  useState,
-} from 'react';
+import { createContext, useContext, useMemo } from 'react';
 
 import { useStack } from '~/hooks/useStack';
-import { noop } from '~/utils';
 
 import { IsMember, Year, Campus, IsMajor, Nickname } from '../Fields';
 

--- a/src/styles/utils/flex.ts
+++ b/src/styles/utils/flex.ts
@@ -7,7 +7,7 @@ type FlexDirection = CSSProperties['flexDirection'];
 type JustifyContent = CSSProperties['justifyContent'];
 type AlignItems = CSSProperties['alignItems'];
 type Gap = CSSProperties['gap'];
-type FlexWrap = CSSProperties['flexWrap'];
+type FlexWrap = CSSProperties['flexWrap'] | undefined;
 
 interface FlexOptions {
   items?: AlignItems;
@@ -22,7 +22,7 @@ const flexCore = (
   justifyContent: JustifyContent = '',
   flexDirection: FlexDirection = 'row',
   gap: Gap = '',
-  flexWrap: FlexWrap = 'nowrap'
+  flexWrap: FlexWrap
 ) => {
   if (typeof alignItems === 'string') {
     return css({
@@ -58,7 +58,7 @@ export function flex(
   justifyContent: JustifyContent = '',
   flexDirection: FlexDirection = 'column',
   gap: Gap = '',
-  flexWrap: FlexWrap = 'nowrap'
+  flexWrap?: FlexWrap
 ) {
   const base = { display: 'flex' };
   return css(
@@ -80,7 +80,7 @@ export function inlineFlex(
   justifyContent: JustifyContent = '',
   flexDirection: FlexDirection = 'column',
   gap: Gap = '',
-  flexWrap: FlexWrap = 'nowrap'
+  flexWrap?: FlexWrap
 ) {
   const base = { display: 'inline-flex' };
   return css(

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -4,4 +4,6 @@ export * from './handleAxiosError';
 export * from './misc';
 export * from './number';
 export * from './webStorage';
+export * from './routes';
+export * from './toWebp';
 export { default as customToast } from './customToast';

--- a/src/utils/toWebp.ts
+++ b/src/utils/toWebp.ts
@@ -1,0 +1,62 @@
+export const MB = (1 << 10) << 10;
+export const byteToMB = (byte: number) => {
+  return (byte / MB).toFixed(2);
+};
+
+export interface ToWebpOptions {
+  maxWebpSize: number;
+  quality: number;
+}
+
+type ToWebp = (
+  file: File,
+  options?: Partial<ToWebpOptions>
+) => Promise<{ blob: Blob; src: string }>;
+
+/* https://github.com/juunini/webp-converter-browser/blob/main/src/index.ts */
+export const toWebp: ToWebp = (file, options = {}) =>
+  new Promise((resolve, reject) => {
+    const { maxWebpSize = MB, quality = 0.8 } = options;
+
+    if (
+      ![
+        'image/webp',
+        'image/png',
+        'image/jpg',
+        'image/jpeg',
+        'image/gif',
+      ].includes(file.type)
+    ) {
+      reject('파일 타입이 유효하지 않습니다.');
+      return;
+    }
+
+    const URL = window.URL;
+    const objectUrl = URL.createObjectURL(file);
+    const canvas = document.createElement('canvas');
+    const context = canvas.getContext('2d') as CanvasRenderingContext2D;
+    const image = new Image();
+
+    image.src = objectUrl;
+    image.crossOrigin = 'anonymous';
+    image.onerror = () => reject('이미지 로드에 실패했습니다.');
+    image.onload = () => {
+      canvas.width = image.width;
+      canvas.height = image.height;
+      context.drawImage(image, 0, 0, canvas.width, canvas.height);
+      canvas.toBlob(
+        (data) => {
+          const blob = data as Blob;
+          if (blob.size > maxWebpSize) {
+            reject(
+              `파일 크기는 ${byteToMB(maxWebpSize)}MB 보다 작아야 합니다.`
+            );
+          }
+
+          resolve({ blob, src: objectUrl });
+        },
+        'image/webp',
+        quality
+      );
+    };
+  });

--- a/yarn.lock
+++ b/yarn.lock
@@ -15360,6 +15360,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-zoom-pan-pinch@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "react-zoom-pan-pinch@npm:3.1.0"
+  peerDependencies:
+    react: "*"
+    react-dom: "*"
+  checksum: 3289cd01edd207697c97303c217e91fe137e3469c39ff54ab51cb17ff8bf8a045b95fb2cc4692b826da2ae69b045589e093e9e561225b696bbc18da95e852242
+  languageName: node
+  linkType: hard
+
 "react@npm:18.2.0":
   version: 18.2.0
   resolution: "react@npm:18.2.0"
@@ -16491,6 +16501,7 @@ __metadata:
     react-quill: ^2.0.0
     react-redux: ^8.0.5
     react-spinners: ^0.13.8
+    react-zoom-pan-pinch: ^3.1.0
     storybook: ^7.0.8
     tsconfig-paths-webpack-plugin: ^4.0.1
     typescript: 5.0.4

--- a/yarn.lock
+++ b/yarn.lock
@@ -5715,6 +5715,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/quill@npm:^1.3.10":
+  version: 1.3.10
+  resolution: "@types/quill@npm:1.3.10"
+  dependencies:
+    parchment: ^1.1.2
+  checksum: e629157d11a8398c945e9d9e6b3ebb678f996b195976ddfcabd9771ac7e55a4ebbab3b0c320dc8eb0033715ea5fd197758ac14b4f50bf1d12fd3648fe24d1cb5
+  languageName: node
+  linkType: hard
+
 "@types/range-parser@npm:*":
   version: 1.2.4
   resolution: "@types/range-parser@npm:1.2.4"
@@ -7758,6 +7767,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"clone@npm:^2.1.1":
+  version: 2.1.2
+  resolution: "clone@npm:2.1.2"
+  checksum: aaf106e9bc025b21333e2f4c12da539b568db4925c0501a1bf4070836c9e848c892fa22c35548ce0d1132b08bbbfa17a00144fe58fccdab6fa900fec4250f67d
+  languageName: node
+  linkType: hard
+
 "co@npm:^4.6.0":
   version: 4.6.0
   resolution: "co@npm:4.6.0"
@@ -8279,6 +8295,20 @@ __metadata:
   version: 0.7.0
   resolution: "dedent@npm:0.7.0"
   checksum: 87de191050d9a40dd70cad01159a0bcf05ecb59750951242070b6abf9569088684880d00ba92a955b4058804f16eeaf91d604f283929b4f614d181cd7ae633d2
+  languageName: node
+  linkType: hard
+
+"deep-equal@npm:^1.0.1":
+  version: 1.1.1
+  resolution: "deep-equal@npm:1.1.1"
+  dependencies:
+    is-arguments: ^1.0.4
+    is-date-object: ^1.0.1
+    is-regex: ^1.0.4
+    object-is: ^1.0.1
+    object-keys: ^1.1.1
+    regexp.prototype.flags: ^1.2.0
+  checksum: f92686f2c5bcdf714a75a5fa7a9e47cb374a8ec9307e717b8d1ce61f56a75aaebf5619c2a12b8087a705b5a2f60d0292c35f8b58cb1f72e3268a3a15cab9f78d
   languageName: node
   linkType: hard
 
@@ -9493,6 +9523,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eventemitter3@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "eventemitter3@npm:2.0.3"
+  checksum: dfbf4a07144afea0712d8e6a7f30ae91beb7c12c36c3d480818488aafa437d9a331327461f82c12dfd60a4fbad502efc97f684089cda02809988b84a23630752
+  languageName: node
+  linkType: hard
+
 "events@npm:^3.2.0, events@npm:^3.3.0":
   version: 3.3.0
   resolution: "events@npm:3.3.0"
@@ -9622,7 +9659,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"extend@npm:^3.0.0":
+"extend@npm:^3.0.0, extend@npm:^3.0.2":
   version: 3.0.2
   resolution: "extend@npm:3.0.2"
   checksum: a50a8309ca65ea5d426382ff09f33586527882cf532931cb08ca786ea3146c0553310bda688710ff61d7668eba9f96b923fe1420cdf56a2c3eaf30fcab87b515
@@ -9658,6 +9695,13 @@ __metadata:
   version: 3.1.3
   resolution: "fast-deep-equal@npm:3.1.3"
   checksum: e21a9d8d84f53493b6aa15efc9cfd53dd5b714a1f23f67fb5dc8f574af80df889b3bce25dc081887c6d25457cce704e636395333abad896ccdec03abaf1f3f9d
+  languageName: node
+  linkType: hard
+
+"fast-diff@npm:1.1.2":
+  version: 1.1.2
+  resolution: "fast-diff@npm:1.1.2"
+  checksum: 2ef726603e22a89ef27225bfaef24c17e3aec188df24da4629d5f012b23a884e09a0c7299ff37a0aec7aa788755bd554f5801f698de4deeffce83308bd11405d
   languageName: node
   linkType: hard
 
@@ -11243,7 +11287,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-regex@npm:^1.1.4":
+"is-regex@npm:^1.0.4, is-regex@npm:^1.1.4":
   version: 1.1.4
   resolution: "is-regex@npm:1.1.4"
   dependencies:
@@ -13073,7 +13117,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.15, lodash@npm:^4.17.20, lodash@npm:^4.17.21":
+"lodash@npm:^4.17.15, lodash@npm:^4.17.20, lodash@npm:^4.17.21, lodash@npm:^4.17.4":
   version: 4.17.21
   resolution: "lodash@npm:4.17.21"
   checksum: eb835a2e51d381e561e508ce932ea50a8e5a68f4ebdd771ea240d3048244a8d13658acbd502cd4829768c56f2e16bdd4340b9ea141297d472517b83868e677f7
@@ -14290,6 +14334,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"parchment@npm:^1.1.2, parchment@npm:^1.1.4":
+  version: 1.1.4
+  resolution: "parchment@npm:1.1.4"
+  checksum: 47997567424d1ad8648046091a06b3a5423ed83f9dfa421d7fd93e0032e79aedd8db5499ff55327e08eebd89d8e927704a646f87d45d4bcfe63016aa5a88947d
+  languageName: node
+  linkType: hard
+
 "parent-module@npm:^1.0.0":
   version: 1.0.1
   resolution: "parent-module@npm:1.0.1"
@@ -14949,6 +15000,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"quill-delta@npm:^3.6.2":
+  version: 3.6.3
+  resolution: "quill-delta@npm:3.6.3"
+  dependencies:
+    deep-equal: ^1.0.1
+    extend: ^3.0.2
+    fast-diff: 1.1.2
+  checksum: e62ed339838077841db401da3181bdf559c6667d014a671767788380c5be13a6205603bcdd27445260e6f6b2b5519161e1000023e521e3b2ff087270fa67fef6
+  languageName: node
+  linkType: hard
+
+"quill@npm:^1.3.7":
+  version: 1.3.7
+  resolution: "quill@npm:1.3.7"
+  dependencies:
+    clone: ^2.1.1
+    deep-equal: ^1.0.1
+    eventemitter3: ^2.0.3
+    extend: ^3.0.2
+    parchment: ^1.1.4
+    quill-delta: ^3.6.2
+  checksum: db3e265a8410a4554e50a18cae4ebc0b43a996a776bcf03e26abcadbf617f4db329d49a0fa3ada6a70538a369bbbdc8fa7a66086f194b481914bf1adbab16f8f
+  languageName: node
+  linkType: hard
+
 "ramda@npm:^0.28.0":
   version: 0.28.0
   resolution: "ramda@npm:0.28.0"
@@ -15124,6 +15200,20 @@ __metadata:
   version: 18.2.0
   resolution: "react-is@npm:18.2.0"
   checksum: e72d0ba81b5922759e4aff17e0252bd29988f9642ed817f56b25a3e217e13eea8a7f2322af99a06edb779da12d5d636e9fda473d620df9a3da0df2a74141d53e
+  languageName: node
+  linkType: hard
+
+"react-quill@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "react-quill@npm:2.0.0"
+  dependencies:
+    "@types/quill": ^1.3.10
+    lodash: ^4.17.4
+    quill: ^1.3.7
+  peerDependencies:
+    react: ^16 || ^17 || ^18
+    react-dom: ^16 || ^17 || ^18
+  checksum: 568e28656ae3a40944d5c4cc9d35accc21834cf15b61a74af4566d8772eb152ce65c0d5ea6da65918cb5c9453c1a2041c60c4a19819bf319bee2e067b613d32b
   languageName: node
   linkType: hard
 
@@ -15408,7 +15498,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"regexp.prototype.flags@npm:^1.4.3, regexp.prototype.flags@npm:^1.5.0":
+"regexp.prototype.flags@npm:^1.2.0, regexp.prototype.flags@npm:^1.4.3, regexp.prototype.flags@npm:^1.5.0":
   version: 1.5.0
   resolution: "regexp.prototype.flags@npm:1.5.0"
   dependencies:
@@ -16367,6 +16457,7 @@ __metadata:
     react-hook-form: ^7.45.0
     react-hot-toast: ^2.4.1
     react-icons: ^4.9.0
+    react-quill: ^2.0.0
     react-redux: ^8.0.5
     react-spinners: ^0.13.8
     storybook: ^7.0.8

--- a/yarn.lock
+++ b/yarn.lock
@@ -3430,6 +3430,36 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-slider@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "@radix-ui/react-slider@npm:1.1.2"
+  dependencies:
+    "@babel/runtime": ^7.13.10
+    "@radix-ui/number": 1.0.1
+    "@radix-ui/primitive": 1.0.1
+    "@radix-ui/react-collection": 1.0.3
+    "@radix-ui/react-compose-refs": 1.0.1
+    "@radix-ui/react-context": 1.0.1
+    "@radix-ui/react-direction": 1.0.1
+    "@radix-ui/react-primitive": 1.0.3
+    "@radix-ui/react-use-controllable-state": 1.0.1
+    "@radix-ui/react-use-layout-effect": 1.0.1
+    "@radix-ui/react-use-previous": 1.0.1
+    "@radix-ui/react-use-size": 1.0.1
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0
+    react-dom: ^16.8 || ^17.0 || ^18.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 2b774f23d90549aa688ee2e500c5325a91ea92db7a5ef245bdf7b5c709078433e6853d4ad84b1367cf701d0f54906979db51baa21e5154b439dde03a365ed270
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-slot@npm:1.0.2, @radix-ui/react-slot@npm:^1.0.2":
   version: 1.0.2
   resolution: "@radix-ui/react-slot@npm:1.0.2"
@@ -16410,6 +16440,7 @@ __metadata:
     "@radix-ui/react-accessible-icon": ^1.0.3
     "@radix-ui/react-dialog": ^1.0.4
     "@radix-ui/react-select": ^1.2.2
+    "@radix-ui/react-slider": ^1.1.2
     "@radix-ui/react-slot": ^1.0.2
     "@reduxjs/toolkit": ^1.9.5
     "@storybook/addon-a11y": ^7.0.8


### PR DESCRIPTION
## Issues

- #74 

<!-- 이슈 번호를 작성해주세요. 여러 이슈 번호를 작성해도 됩니다. -->

## 구분

- [x] 버그 수정
- [x] 기능 추가
- [x] 코드 리팩터링
- [ ] 문서 업데이트
- [ ] 기타

<!-- 어떤 이유로 코드를 변경했는지 체크해주세요. -->

## 주요 변경점

- [x] 커스텀 툴바에 이미지 업로드 버튼 추가
- [x] `.jpg`, `.png`만 받음. => `.gif`, `.webp`도 지원
- [x] 업로드시 webp변환
- [x] 최대 업로드 용량 10mb
- [ ] 최대 업로드 개수 3개 -> 아직
- [x] 업로드된 이미지 썸네일바에 표시
- [x] 썸네일바 커스텀
- [x] 미리보기 모달

<!-- 주요 변경점과 어떤 부분을 집중해서 리뷰해야 하는지 알려주세요. -->

## 스크린샷


<!-- 관련 미디어 파일이 있으면 첨부해주세요. -->

## 기타

<!-- 추가로 전달할 내용, 메모할 내용, 테스트 계획, 완료된 테스트 등을 알려주세요. -->

이미지 업로드 방식이 변경될 것 같아서, 이미지 업로드를 하는데 필요한 데이터 구조까지 세부적으로 정의하진 못했고 간단하게 img src의 배열로 생각해서, `string[]`타입으로만 구현해놨어요.


