### PR TITLE
내정보 수정 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@tanstack/react-query": "^4.29.5",
     "axios": "^1.4.0",
     "dayjs": "^1.11.8",
+    "immer": "^10.0.2",
     "is-what": "^4.1.15",
     "jotai": "^2.2.2",
     "next": "13.3.4",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "react-error-boundary": "^4.0.4",
     "storybook": "^7.0.27",
     "tsconfig-paths-webpack-plugin": "^4.0.1",
+    "type-fest": "^4.0.0",
     "typescript": "5.0.4"
   },
   "msw": {

--- a/src/components/Forms/Common/Nickname/index.tsx
+++ b/src/components/Forms/Common/Nickname/index.tsx
@@ -10,12 +10,13 @@ import { flex } from '~/styles/utils';
 
 interface NicknameProps {
   fieldName: string;
+  initialNickname: string;
   className?: string;
   id?: string;
 }
 
 const Nickname = (props: NicknameProps) => {
-  const { fieldName, className, id } = props;
+  const { fieldName, className, id, initialNickname } = props;
   const { register, setFocus, setValue } = useFormContext();
 
   const handleCreateRandomNickname = () => {
@@ -25,9 +26,9 @@ const Nickname = (props: NicknameProps) => {
     setFocus(fieldName);
   };
 
-  const preventSubmitOnEnterKeyDown: KeyboardEventHandler<
-    HTMLInputElement
-  > = (e) => {
+  const preventSubmitOnEnterKeyDown: KeyboardEventHandler<HTMLInputElement> = (
+    e
+  ) => {
     if (e.key === 'Enter') e.preventDefault();
   };
 
@@ -47,7 +48,7 @@ const Nickname = (props: NicknameProps) => {
         type="text"
         autoComplete="off"
         {...register(fieldName, {
-          validate: nicknameValidator,
+          validate: (value) => nicknameValidator(value, initialNickname),
         })}
       />
       <ErrorMessage

--- a/src/components/Forms/MyInfoEditForm/Fields/IsMajor.tsx
+++ b/src/components/Forms/MyInfoEditForm/Fields/IsMajor.tsx
@@ -20,7 +20,7 @@ export const IsMajor = () => {
 
   const onIsMajorChange = (value: string) => {
     const isMajorValue = value === Major.MAJOR;
-    setValue(fieldName, isMajorValue);
+    setValue(fieldName, isMajorValue, { shouldDirty: true });
   };
 
   register(fieldName, {
@@ -30,6 +30,7 @@ export const IsMajor = () => {
   return (
     <div css={selfCss}>
       <SelectBox
+        focusOnMount
         defaultValue={defaultIsMajor ? Major.MAJOR : Major.NON_MAJOR}
         size="lg"
         items={Object.values(Major)}

--- a/src/components/Forms/MyInfoEditForm/Fields/IsMajor.tsx
+++ b/src/components/Forms/MyInfoEditForm/Fields/IsMajor.tsx
@@ -24,7 +24,10 @@ export const IsMajor = () => {
   };
 
   register(fieldName, {
-    validate: (value) => isBoolean(value),
+    validate: (value) => {
+      if (!isBoolean(value)) return '전공자 여부는 필수로 선택해야 합니다.';
+      return defaultIsMajor !== value;
+    },
   });
 
   return (

--- a/src/components/Forms/MyInfoEditForm/Fields/IsMajor.tsx
+++ b/src/components/Forms/MyInfoEditForm/Fields/IsMajor.tsx
@@ -1,0 +1,42 @@
+import { css } from '@emotion/react';
+import { isBoolean } from 'is-what';
+
+import { SelectBox } from '~/components/Common';
+import { useMyInfoEditFormContext } from '~/components/Forms/MyInfoEditForm/utils';
+
+enum Major {
+  MAJOR = '전공자',
+  NON_MAJOR = '비전공자',
+}
+
+const fieldName = 'isMajor';
+
+export const IsMajor = () => {
+  const {
+    register,
+    setValue,
+    formState: { defaultValues: { isMajor: defaultIsMajor } = {} },
+  } = useMyInfoEditFormContext();
+
+  const onIsMajorChange = (value: string) => {
+    const isMajorValue = value === Major.MAJOR;
+    setValue(fieldName, isMajorValue);
+  };
+
+  register(fieldName, {
+    validate: (value) => isBoolean(value),
+  });
+
+  return (
+    <div css={selfCss}>
+      <SelectBox
+        defaultValue={defaultIsMajor ? Major.MAJOR : Major.NON_MAJOR}
+        size="lg"
+        items={Object.values(Major)}
+        onValueChange={onIsMajorChange}
+      />
+    </div>
+  );
+};
+
+const selfCss = css({});

--- a/src/components/Forms/MyInfoEditForm/Fields/SsafyBasicInfo.tsx
+++ b/src/components/Forms/MyInfoEditForm/Fields/SsafyBasicInfo.tsx
@@ -23,30 +23,47 @@ enum IsSsafyMember {
   NO = '아니오',
 }
 
+const resolveSsafyMemberFieldValue = (value?: boolean) => {
+  if (!isBoolean(value)) return value;
+  return value ? IsSsafyMember.YES : IsSsafyMember.NO;
+};
+
 export const SsafyBasicInfo = () => {
   const { data: campuses } = useCampuses();
   const { data: years } = useYears();
-  const { register, setValue } = useMyInfoEditFormContext();
+  const {
+    register,
+    setValue,
+    formState: { defaultValues = {} },
+  } = useMyInfoEditFormContext();
+  const { ssafyBasicInfo: { campus: defaultCampus, year: defaultYear } = {} } =
+    defaultValues;
+
   const ssafyMemberSelectBoxId = useId();
   const yearSelectBoxId = useId();
   const campusSelectBoxId = useId();
 
   const ssafyMember = useWatch<MyInfoEditFormValues>({
     name: ssafyMemberFieldName,
-    defaultValue: false,
-  }) as boolean;
+  }) as boolean | undefined;
 
   const handleSelectSsafyMember = (value: string) => {
     const fieldValue = value === IsSsafyMember.YES;
-    setValue(ssafyMemberFieldName, fieldValue);
+    setValue(ssafyMemberFieldName, fieldValue, {
+      shouldDirty: true,
+    });
   };
 
   const handleSelectYear = (value: string) => {
-    setValue(yearFieldName, Number(extractNumericText(value)));
+    setValue(yearFieldName, Number(extractNumericText(value)), {
+      shouldDirty: true,
+    });
   };
 
   const handleSelectCampus = (value: string) => {
-    setValue(campusFieldName, value);
+    setValue(campusFieldName, value, {
+      shouldDirty: true,
+    });
   };
 
   register(ssafyMemberFieldName, {
@@ -84,7 +101,7 @@ export const SsafyBasicInfo = () => {
         <SelectBox
           id={ssafyMemberSelectBoxId}
           size="lg"
-          value={ssafyMember ? IsSsafyMember.YES : IsSsafyMember.NO}
+          value={resolveSsafyMemberFieldValue(ssafyMember)}
           items={Object.values(IsSsafyMember)}
           onValueChange={handleSelectSsafyMember}
         />
@@ -96,6 +113,7 @@ export const SsafyBasicInfo = () => {
         style={{ zIndex: 2 }}
       >
         <SelectBox
+          defaultValue={String(defaultYear)}
           disabled={!ssafyMember}
           id={yearSelectBoxId}
           size="lg"
@@ -111,6 +129,7 @@ export const SsafyBasicInfo = () => {
         style={{ zIndex: 1 }}
       >
         <SelectBox
+          defaultValue={defaultCampus}
           disabled={!ssafyMember}
           id={campusSelectBoxId}
           size="lg"

--- a/src/components/Forms/MyInfoEditForm/Fields/SsafyBasicInfo.tsx
+++ b/src/components/Forms/MyInfoEditForm/Fields/SsafyBasicInfo.tsx
@@ -1,0 +1,126 @@
+import type { MyInfoEditFormValues } from '~/components/Forms/MyInfoEditForm/utils';
+
+import { css } from '@emotion/react';
+import { isBoolean } from 'is-what';
+import { useId } from 'react';
+import { useWatch } from 'react-hook-form';
+
+import { SelectBox } from '~/components/Common';
+import Label from '~/components/Common/Label';
+import { useMyInfoEditFormContext } from '~/components/Forms/MyInfoEditForm/utils';
+import campus from '~/components/Forms/UserRegisterForm/Fields/Campus';
+import { extractNumericText } from '~/services/member';
+import { useCampuses, useYears } from '~/services/meta';
+import { flex } from '~/styles/utils';
+
+const ssafyBasicInfoFieldName = 'ssafyBasicInfo' as const;
+const ssafyMemberFieldName = `${ssafyBasicInfoFieldName}.ssafyMember` as const;
+const yearFieldName = `${ssafyBasicInfoFieldName}.year` as const;
+const campusFieldName = `${ssafyBasicInfoFieldName}.campus` as const;
+
+enum IsSsafyMember {
+  YES = '네',
+  NO = '아니오',
+}
+
+export const SsafyBasicInfo = () => {
+  const { data: campuses } = useCampuses();
+  const { data: years } = useYears();
+  const { register, setValue } = useMyInfoEditFormContext();
+  const ssafyMemberSelectBoxId = useId();
+  const yearSelectBoxId = useId();
+  const campusSelectBoxId = useId();
+
+  const ssafyMember = useWatch<MyInfoEditFormValues>({
+    name: ssafyMemberFieldName,
+    defaultValue: false,
+  }) as boolean;
+
+  const handleSelectSsafyMember = (value: string) => {
+    const fieldValue = value === IsSsafyMember.YES;
+    setValue(ssafyMemberFieldName, fieldValue);
+  };
+
+  const handleSelectYear = (value: string) => {
+    setValue(yearFieldName, Number(extractNumericText(value)));
+  };
+
+  const handleSelectCampus = (value: string) => {
+    setValue(campusFieldName, value);
+  };
+
+  register(ssafyMemberFieldName, {
+    validate: (value) => isBoolean(value),
+  });
+
+  register(yearFieldName, {
+    validate: (value, formValues) => {
+      if (formValues.ssafyBasicInfo.ssafyMember) {
+        if (value === undefined) return '기수를 선택해주세요.';
+      }
+
+      return true;
+    },
+  });
+
+  register(campusFieldName, {
+    validate: (value, formValues) => {
+      if (formValues.ssafyBasicInfo.ssafyMember) {
+        if (value === undefined) return '캠퍼스를 선택해주세요.';
+      }
+
+      return true;
+    },
+  });
+
+  return (
+    <div css={selfCss}>
+      <Label
+        htmlFor={ssafyMemberSelectBoxId}
+        css={labelCss}
+        name="SSAFY인 여부"
+        style={{ zIndex: 3 }}
+      >
+        <SelectBox
+          id={ssafyMemberSelectBoxId}
+          size="lg"
+          value={ssafyMember ? IsSsafyMember.YES : IsSsafyMember.NO}
+          items={Object.values(IsSsafyMember)}
+          onValueChange={handleSelectSsafyMember}
+        />
+      </Label>
+      <Label
+        htmlFor={yearSelectBoxId}
+        css={labelCss}
+        name="SSAFY 기수 선택"
+        style={{ zIndex: 2 }}
+      >
+        <SelectBox
+          disabled={!ssafyMember}
+          id={yearSelectBoxId}
+          size="lg"
+          items={years.map(String)}
+          textAs={(value) => value + '기'}
+          onValueChange={handleSelectYear}
+        />
+      </Label>
+      <Label
+        htmlFor={campusSelectBoxId}
+        css={labelCss}
+        name="SSAFY 캠퍼스 선택"
+        style={{ zIndex: 1 }}
+      >
+        <SelectBox
+          disabled={!ssafyMember}
+          id={campusSelectBoxId}
+          size="lg"
+          items={campuses}
+          onValueChange={handleSelectCampus}
+        />
+      </Label>
+    </div>
+  );
+};
+
+const selfCss = css(flex('', 'flex-start', 'column', 30));
+const labelCss = css({ position: 'relative' });

--- a/src/components/Forms/MyInfoEditForm/Fields/Track.tsx
+++ b/src/components/Forms/MyInfoEditForm/Fields/Track.tsx
@@ -16,11 +16,16 @@ export const Track = () => {
   } = useMyInfoEditFormContext();
 
   const handleChangeTrack = (value: string) => {
-    setValue(fieldName, value);
+    setValue(fieldName, value, {
+      shouldDirty: true,
+    });
   };
 
   register(fieldName, {
     required: true,
+    validate: (value) => {
+      return defaultTrack !== value;
+    },
   });
 
   return (

--- a/src/components/Forms/MyInfoEditForm/Fields/Track.tsx
+++ b/src/components/Forms/MyInfoEditForm/Fields/Track.tsx
@@ -26,9 +26,11 @@ export const Track = () => {
   return (
     <div css={selfCss}>
       <SelectBox
+        focusOnMount
         defaultValue={defaultTrack}
         size="lg"
-        items={tracks.map((track) => capitalize(track))}
+        items={tracks}
+        textAs={(value) => capitalize(value)}
         onValueChange={handleChangeTrack}
       />
     </div>

--- a/src/components/Forms/MyInfoEditForm/Fields/Track.tsx
+++ b/src/components/Forms/MyInfoEditForm/Fields/Track.tsx
@@ -1,0 +1,38 @@
+import { css } from '@emotion/react';
+
+import { SelectBox } from '~/components/Common';
+import { useMyInfoEditFormContext } from '~/components/Forms/MyInfoEditForm/utils';
+import { useTracks } from '~/services/meta';
+import { capitalize } from '~/utils';
+
+const fieldName = 'track';
+
+export const Track = () => {
+  const { data: tracks } = useTracks();
+  const {
+    register,
+    setValue,
+    formState: { defaultValues: { track: defaultTrack } = {} },
+  } = useMyInfoEditFormContext();
+
+  const handleChangeTrack = (value: string) => {
+    setValue(fieldName, value);
+  };
+
+  register(fieldName, {
+    required: true,
+  });
+
+  return (
+    <div css={selfCss}>
+      <SelectBox
+        defaultValue={defaultTrack}
+        size="lg"
+        items={tracks.map((track) => capitalize(track))}
+        onValueChange={handleChangeTrack}
+      />
+    </div>
+  );
+};
+
+const selfCss = css({});

--- a/src/components/Forms/MyInfoEditForm/Fields/index.ts
+++ b/src/components/Forms/MyInfoEditForm/Fields/index.ts
@@ -1,2 +1,4 @@
 export * from './SsafyBasicInfo';
 export * from './IsMajor';
+export * from './Track';
+

--- a/src/components/Forms/MyInfoEditForm/Fields/index.ts
+++ b/src/components/Forms/MyInfoEditForm/Fields/index.ts
@@ -1,1 +1,2 @@
 export * from './SsafyBasicInfo';
+export * from './IsMajor';

--- a/src/components/Forms/MyInfoEditForm/Fields/index.ts
+++ b/src/components/Forms/MyInfoEditForm/Fields/index.ts
@@ -1,0 +1,1 @@
+export * from './SsafyBasicInfo';

--- a/src/components/Forms/MyInfoEditForm/index.tsx
+++ b/src/components/Forms/MyInfoEditForm/index.tsx
@@ -10,7 +10,7 @@ import { Nickname } from '~/components/Forms/UserRegisterForm/Fields';
 import TitleBar from '~/components/TitleBar';
 import { flex, pageMinHeight } from '~/styles/utils';
 
-import { SsafyBasicInfo, IsMajor } from './Fields';
+import { SsafyBasicInfo, IsMajor, Track } from './Fields';
 
 type MyInfoEditFormFields = keyof MyInfoEditFormValues;
 
@@ -56,7 +56,7 @@ const MyInfoEditForm = (props: MyInfoEditFormProps) => {
         )}
         {field === 'ssafyBasicInfo' && <SsafyBasicInfo />}
         {field === 'isMajor' && <IsMajor />}
-        {field === 'track' && <></>}
+        {field === 'track' && <Track />}
 
         {field !== 'nickname' && (
           <Button size="lg" type="submit">

--- a/src/components/Forms/MyInfoEditForm/index.tsx
+++ b/src/components/Forms/MyInfoEditForm/index.tsx
@@ -21,7 +21,7 @@ const titleMap: Record<MyInfoEditFormFields, string> = {
   track: 'SSAFY 트랙',
 };
 
-interface MyInfoEditFormProps {
+export interface MyInfoEditFormProps {
   field: MyInfoEditFormFields;
   defaultValues: PartialDeep<MyInfoEditFormValues>;
   onValidSubmit: SubmitHandler<MyInfoEditFormValues>;
@@ -39,7 +39,7 @@ const MyInfoEditForm = (props: MyInfoEditFormProps) => {
 
   const {
     handleSubmit,
-    formState: { isDirty },
+    formState: { isDirty, isSubmitting },
   } = methods;
 
   return (
@@ -49,7 +49,7 @@ const MyInfoEditForm = (props: MyInfoEditFormProps) => {
         className={className}
         onSubmit={handleSubmit(onValidSubmit, onInvalidSubmit)}
       >
-        <TitleBar.Default title={titleMap[field]} withoutClose />
+        <TitleBar.Default title={titleMap[field]} withoutClose  />
         {field === 'nickname' && (
           <Nickname
             buttonText="수정 완료"
@@ -62,7 +62,12 @@ const MyInfoEditForm = (props: MyInfoEditFormProps) => {
         {field === 'track' && <Track />}
 
         {field !== 'nickname' && (
-          <Button size="lg" type="submit" disabled={!isDirty}>
+          <Button
+            size="lg"
+            type="submit"
+            disabled={!isDirty}
+            loading={isSubmitting}
+          >
             수정 완료
           </Button>
         )}

--- a/src/components/Forms/MyInfoEditForm/index.tsx
+++ b/src/components/Forms/MyInfoEditForm/index.tsx
@@ -1,0 +1,78 @@
+import type { MyInfoEditFormValues } from './utils';
+import type { SubmitErrorHandler, SubmitHandler } from 'react-hook-form';
+import type { PartialDeep } from 'type-fest';
+
+import { css } from '@emotion/react';
+import { FormProvider, useForm } from 'react-hook-form';
+
+import { Button } from '~/components/Common';
+import { Nickname } from '~/components/Forms/UserRegisterForm/Fields';
+import TitleBar from '~/components/TitleBar';
+import { flex, pageMinHeight } from '~/styles/utils';
+
+import { SsafyBasicInfo } from './Fields';
+
+type MyInfoEditFormFields = keyof MyInfoEditFormValues;
+
+const titleMap: Record<MyInfoEditFormFields, string> = {
+  nickname: '닉네임 수정',
+  isMajor: 'SSAFY 전공자',
+  ssafyBasicInfo: 'SSAFY 기본정보',
+  track: 'SSAFY 트랙',
+};
+
+interface MyInfoEditFormProps {
+  field: MyInfoEditFormFields;
+  defaultValues: PartialDeep<MyInfoEditFormValues>;
+  onValidSubmit: SubmitHandler<MyInfoEditFormValues>;
+  onInvalidSubmit?: SubmitErrorHandler<MyInfoEditFormValues>;
+  className?: string;
+}
+
+const MyInfoEditForm = (props: MyInfoEditFormProps) => {
+  const { field, defaultValues, onValidSubmit, onInvalidSubmit, className } =
+    props;
+
+  const methods = useForm<MyInfoEditFormValues>({
+    defaultValues,
+  });
+
+  const { handleSubmit } = methods;
+
+  return (
+    <FormProvider {...methods}>
+      <form
+        css={selfCss}
+        className={className}
+        onSubmit={handleSubmit(onValidSubmit, onInvalidSubmit)}
+      >
+        <TitleBar.Default title={titleMap[field]} withoutClose />
+        {field === 'nickname' && (
+          <Nickname
+            buttonText="수정 완료"
+            initialNickname={defaultValues.nickname}
+            withLabelText={false}
+          />
+        )}
+        {field === 'ssafyBasicInfo' && <SsafyBasicInfo />}
+        {field === 'isMajor' && <></>}
+        {field === 'track' && <></>}
+
+        {field !== 'nickname' && (
+          <Button size="lg" type="submit">
+            수정 완료
+          </Button>
+        )}
+      </form>
+    </FormProvider>
+  );
+};
+
+export default MyInfoEditForm;
+
+const selfCss = css(
+  {
+    minHeight: pageMinHeight,
+  },
+  flex('', 'space-between')
+);

--- a/src/components/Forms/MyInfoEditForm/index.tsx
+++ b/src/components/Forms/MyInfoEditForm/index.tsx
@@ -10,7 +10,7 @@ import { Nickname } from '~/components/Forms/UserRegisterForm/Fields';
 import TitleBar from '~/components/TitleBar';
 import { flex, pageMinHeight } from '~/styles/utils';
 
-import { SsafyBasicInfo } from './Fields';
+import { SsafyBasicInfo, IsMajor } from './Fields';
 
 type MyInfoEditFormFields = keyof MyInfoEditFormValues;
 
@@ -55,7 +55,7 @@ const MyInfoEditForm = (props: MyInfoEditFormProps) => {
           />
         )}
         {field === 'ssafyBasicInfo' && <SsafyBasicInfo />}
-        {field === 'isMajor' && <></>}
+        {field === 'isMajor' && <IsMajor />}
         {field === 'track' && <></>}
 
         {field !== 'nickname' && (

--- a/src/components/Forms/MyInfoEditForm/index.tsx
+++ b/src/components/Forms/MyInfoEditForm/index.tsx
@@ -37,7 +37,10 @@ const MyInfoEditForm = (props: MyInfoEditFormProps) => {
     defaultValues,
   });
 
-  const { handleSubmit } = methods;
+  const {
+    handleSubmit,
+    formState: { isDirty },
+  } = methods;
 
   return (
     <FormProvider {...methods}>
@@ -59,7 +62,7 @@ const MyInfoEditForm = (props: MyInfoEditFormProps) => {
         {field === 'track' && <Track />}
 
         {field !== 'nickname' && (
-          <Button size="lg" type="submit">
+          <Button size="lg" type="submit" disabled={!isDirty}>
             수정 완료
           </Button>
         )}

--- a/src/components/Forms/MyInfoEditForm/index.tsx
+++ b/src/components/Forms/MyInfoEditForm/index.tsx
@@ -21,17 +21,28 @@ const titleMap: Record<MyInfoEditFormFields, string> = {
   track: 'SSAFY 트랙',
 };
 
+interface MyInfoEditFormPropsOptions {
+  forceSsafyMemberToTrue: boolean;
+}
+
 export interface MyInfoEditFormProps {
   field: MyInfoEditFormFields;
   defaultValues: PartialDeep<MyInfoEditFormValues>;
   onValidSubmit: SubmitHandler<MyInfoEditFormValues>;
   onInvalidSubmit?: SubmitErrorHandler<MyInfoEditFormValues>;
   className?: string;
+  options?: Partial<MyInfoEditFormPropsOptions>;
 }
 
 const MyInfoEditForm = (props: MyInfoEditFormProps) => {
-  const { field, defaultValues, onValidSubmit, onInvalidSubmit, className } =
-    props;
+  const {
+    field,
+    defaultValues,
+    onValidSubmit,
+    onInvalidSubmit,
+    className,
+    options: { forceSsafyMemberToTrue } = {},
+  } = props;
 
   const methods = useForm<MyInfoEditFormValues>({
     defaultValues,
@@ -49,7 +60,7 @@ const MyInfoEditForm = (props: MyInfoEditFormProps) => {
         className={className}
         onSubmit={handleSubmit(onValidSubmit, onInvalidSubmit)}
       >
-        <TitleBar.Default title={titleMap[field]} withoutClose  />
+        <TitleBar.Default title={titleMap[field]} withoutClose />
         {field === 'nickname' && (
           <Nickname
             buttonText="수정 완료"
@@ -57,7 +68,9 @@ const MyInfoEditForm = (props: MyInfoEditFormProps) => {
             withLabelText={false}
           />
         )}
-        {field === 'ssafyBasicInfo' && <SsafyBasicInfo />}
+        {field === 'ssafyBasicInfo' && (
+          <SsafyBasicInfo forceSsafyMemberToTrue={forceSsafyMemberToTrue} />
+        )}
         {field === 'isMajor' && <IsMajor />}
         {field === 'track' && <Track />}
 

--- a/src/components/Forms/MyInfoEditForm/utils/index.ts
+++ b/src/components/Forms/MyInfoEditForm/utils/index.ts
@@ -1,0 +1,2 @@
+export * from './types';
+export * from './useMyInfoEditFormContext';

--- a/src/components/Forms/MyInfoEditForm/utils/types.ts
+++ b/src/components/Forms/MyInfoEditForm/utils/types.ts
@@ -1,0 +1,12 @@
+import type { UserRegisterFormValues } from '~/components/Forms/UserRegisterForm/utils';
+
+export interface MyInfoEditFormValues
+  extends Pick<UserRegisterFormValues, 'nickname'> {
+  ssafyBasicInfo: {
+    ssafyMember: boolean;
+    year: number;
+    campus: string;
+  };
+  isMajor: boolean;
+  track: string;
+}

--- a/src/components/Forms/MyInfoEditForm/utils/useMyInfoEditFormContext.ts
+++ b/src/components/Forms/MyInfoEditForm/utils/useMyInfoEditFormContext.ts
@@ -1,0 +1,7 @@
+import type { MyInfoEditFormValues } from './types';
+
+import { useFormContext } from 'react-hook-form';
+
+export const useMyInfoEditFormContext = () => {
+  return useFormContext<MyInfoEditFormValues>();
+};

--- a/src/components/Forms/StudentCertificationForm/index.tsx
+++ b/src/components/Forms/StudentCertificationForm/index.tsx
@@ -47,7 +47,6 @@ const StudentCertificationForm = (props: StudentCertificationFormProps) => {
     <div css={selfCss} className={className}>
       <FormProvider {...methods}>
         <TitleBar.Default
-          css={titleBarCss}
           title="SSAFY 재학생 인증"
           withoutBackward={currentPhase === 0}
           withoutClose
@@ -71,10 +70,6 @@ const defaultStudentCertificationFormValues: Partial<StudentCertificationFormVal
 export default StudentCertificationForm;
 
 const selfCss = css({ minHeight: pageMinHeight }, flex());
-
-const titleBarCss = css({
-  padding: 0,
-});
 
 const formCss = css(
   {

--- a/src/components/Forms/UserRegisterForm/Fields/Nickname.tsx
+++ b/src/components/Forms/UserRegisterForm/Fields/Nickname.tsx
@@ -101,7 +101,7 @@ const Nickname = (props: NicknameProps) => {
   return (
     <div css={selfCss} className={className}>
       {withLabelText && (
-        <label htmlFor={nicknameFieldId}>
+        <label htmlFor={nicknameFieldId} css={[labelCss, { marginBottom: 40 }]}>
           <div css={fontCss.style.B28}>
             <p>닉네임을</p>
             <p>입력해주세요</p>
@@ -141,10 +141,5 @@ const buttonCss = css({ width: '100%' });
 
 const selfCss = css({ flexGrow: 1 }, flex());
 
-const inputContainerCss = css(
-  {
-    flexGrow: 1,
-    marginTop: 40,
-  },
-  flex('', '', 'column', 10)
-);
+const labelCss = css({ display: 'block' });
+const inputContainerCss = css({ flexGrow: 1 }, flex('', '', 'column', 10));

--- a/src/components/Forms/UserRegisterForm/Fields/Nickname.tsx
+++ b/src/components/Forms/UserRegisterForm/Fields/Nickname.tsx
@@ -111,6 +111,7 @@ const Nickname = (props: NicknameProps) => {
 
       <NicknameField
         id={nicknameFieldId}
+        initialNickname={initialNickname}
         css={inputContainerCss}
         fieldName={fieldName}
       />

--- a/src/components/Forms/UserRegisterForm/Fields/Year.tsx
+++ b/src/components/Forms/UserRegisterForm/Fields/Year.tsx
@@ -3,6 +3,7 @@ import { useEffect } from 'react';
 
 import { SelectBox } from '~/components/Common';
 import { useUserRegisterFormContext } from '~/components/Forms/UserRegisterForm/utils';
+import { extractNumericText } from '~/services/member';
 import { flex, fontCss } from '~/styles/utils';
 
 const years = Array(10)
@@ -10,7 +11,6 @@ const years = Array(10)
   .map((_, i) => `${i + 1}기`);
 
 const fieldName = 'year';
-const filterNumericText = (value: string) => value.replace(/\D/g, '');
 
 interface YearProps {
   onSelect: () => void;
@@ -39,7 +39,7 @@ const Year = (props: YearProps) => {
       <SelectBox
         items={years}
         onValueChange={handleValueChange}
-        valueAs={filterNumericText}
+        valueAs={extractNumericText}
         size="lg"
         focusOnMount
       />

--- a/src/components/TitleBar/DefaultTitleBar.tsx
+++ b/src/components/TitleBar/DefaultTitleBar.tsx
@@ -5,14 +5,7 @@ import { useRouter } from 'next/router';
 import { css } from '@emotion/react';
 
 import { Bar, Icon, IconButton } from '~/components/Common';
-import {
-  fixTopCenter,
-  fontCss,
-  pageMaxWidth,
-  pageMinWidth,
-  position,
-  zIndex,
-} from '~/styles/utils';
+import { fixTopCenter, fontCss, zIndex } from '~/styles/utils';
 
 interface DefaultTitleBarProps {
   title?: string;
@@ -22,6 +15,12 @@ interface DefaultTitleBarProps {
   withoutClose?: boolean;
   onClickBackward?: MouseEventHandler<HTMLButtonElement>;
   onClickClose?: MouseEventHandler<HTMLButtonElement>;
+
+  /**
+   * - onClickBackward를 명시하지 않고, 여기에 path 를 입력하면 뒤로가기 버튼 누를 시 해당 path로 이동합니다.
+   * - onClickBackward와 backwardAs를 모두 입력하지 않으면 기본값은 뒤로가기입니다.
+   */
+  backwardAs?: string;
 }
 
 const DefaultTitleBar = (props: DefaultTitleBarProps) => {
@@ -32,12 +31,14 @@ const DefaultTitleBar = (props: DefaultTitleBarProps) => {
     withoutClose = false,
     onClickBackward,
     onClickClose,
+    backwardAs,
     ...restProps
   } = props;
   const router = useRouter();
 
   const defaultHandleClickBackward = () => {
-    router.back();
+    if (backwardAs) return router.push(backwardAs);
+    return router.back();
   };
 
   return (

--- a/src/mocks/handlers/member/index.ts
+++ b/src/mocks/handlers/member/index.ts
@@ -95,6 +95,16 @@ export const updateNicknameError = restError(
   }
 );
 
+export const updateIsMajor = restSuccess(
+  'patch',
+  composeUrls(API_URL, endpoints.user.isMajor())
+);
+
+export const updateIsMajorError = restError(
+  'patch',
+  composeUrls(API_URL, endpoints.user.isMajor())
+);
+
 export const certifyStudent = restSuccess<CertifyStudentApiData['data']>(
   'post',
   composeUrls(API_URL, endpoints.user.studentCertification()),
@@ -131,4 +141,5 @@ export const memberHandlers = [
   validateNickname,
   certifyStudent,
   updateNickname,
+  updateIsMajor,
 ];

--- a/src/mocks/handlers/member/index.ts
+++ b/src/mocks/handlers/member/index.ts
@@ -20,9 +20,9 @@ const getMyInfo = rest.get<never, never, GetMyInfoApiData | ApiErrorResponse>(
     return res(
       ctx.delay(500),
       // ...mockSuccess<UserInfo>(ctx, userInfo.initialUserInfo)
-      ...mockSuccess<UserInfo>(ctx, userInfo.certifiedSsafyUserInfo)
+      // ...mockSuccess<UserInfo>(ctx, userInfo.certifiedSsafyUserInfo)
       // ...mockSuccess<UserInfo>(ctx, userInfo.uncertifiedSsafyUserInfo)
-      // ...mockSuccess<UserInfo>(ctx, userInfo.nonSsafyUserInfo)
+      ...mockSuccess<UserInfo>(ctx, userInfo.nonSsafyUserInfo)
       // ...mockError(ctx, 'code', 'message', 404),
     );
   }

--- a/src/mocks/handlers/member/index.ts
+++ b/src/mocks/handlers/member/index.ts
@@ -20,9 +20,9 @@ const getMyInfo = rest.get<never, never, GetMyInfoApiData | ApiErrorResponse>(
     return res(
       ctx.delay(500),
       // ...mockSuccess<UserInfo>(ctx, userInfo.initialUserInfo)
-      // ...mockSuccess<UserInfo>(ctx, userInfo.certifiedSsafyUserInfo)
+      ...mockSuccess<UserInfo>(ctx, userInfo.certifiedSsafyUserInfo)
       // ...mockSuccess<UserInfo>(ctx, userInfo.uncertifiedSsafyUserInfo)
-      ...mockSuccess<UserInfo>(ctx, userInfo.nonSsafyUserInfo)
+      // ...mockSuccess<UserInfo>(ctx, userInfo.nonSsafyUserInfo)
       // ...mockError(ctx, 'code', 'message', 404),
     );
   }
@@ -82,6 +82,19 @@ export const validateNicknameError = restError(
   }
 );
 
+export const updateNickname = restSuccess(
+  'patch',
+  composeUrls(API_URL, endpoints.user.nickname())
+);
+
+export const updateNicknameError = restError(
+  'patch',
+  composeUrls(API_URL, endpoints.user.nickname()),
+  {
+    message: '유효하지 않은 닉네임입니다.',
+  }
+);
+
 export const certifyStudent = restSuccess<CertifyStudentApiData['data']>(
   'post',
   composeUrls(API_URL, endpoints.user.studentCertification()),
@@ -117,4 +130,5 @@ export const memberHandlers = [
   updateMyInfo,
   validateNickname,
   certifyStudent,
+  updateNickname,
 ];

--- a/src/mocks/handlers/member/index.ts
+++ b/src/mocks/handlers/member/index.ts
@@ -102,7 +102,33 @@ export const updateIsMajor = restSuccess(
 
 export const updateIsMajorError = restError(
   'patch',
-  composeUrls(API_URL, endpoints.user.isMajor())
+  composeUrls(API_URL, endpoints.user.isMajor()),
+  {
+    message: '오류가 발생했습니다.',
+  }
+);
+
+export const updateSsafyBasicInfo = restSuccess(
+  'patch',
+  composeUrls(API_URL, endpoints.user.ssafyBasicInfo())
+);
+
+export const updateSsafyBasicInfoError = restError(
+  'patch',
+  composeUrls(API_URL, endpoints.user.ssafyBasicInfo()),
+  {
+    message: '오류가 발생했습니다.',
+  }
+);
+
+export const updateTrack = restSuccess(
+  'patch',
+  composeUrls(API_URL, endpoints.user.track())
+);
+
+export const updateTrackError = restError(
+  'patch',
+  composeUrls(API_URL, endpoints.user.track())
 );
 
 export const certifyStudent = restSuccess<CertifyStudentApiData['data']>(
@@ -142,4 +168,6 @@ export const memberHandlers = [
   certifyStudent,
   updateNickname,
   updateIsMajor,
+  updateSsafyBasicInfo,
+  updateTrack,
 ];

--- a/src/pages/certification/student/index.tsx
+++ b/src/pages/certification/student/index.tsx
@@ -18,7 +18,7 @@ import {
   useMyInfo,
   useSetMyInfo,
 } from '~/services/member';
-import { flex } from '~/styles/utils';
+import { flex, titleBarHeight } from '~/styles/utils';
 import {
   customToast,
   handleAxiosError,
@@ -165,7 +165,7 @@ StudentCertificationPage.auth = {
 const selfCss = css(
   {
     minHeight: '100vh',
-    padding: '10px 15px',
+    padding: `${titleBarHeight}px 15px`,
   },
   flex()
 );

--- a/src/pages/profile/myinfo-settings/index.tsx
+++ b/src/pages/profile/myinfo-settings/index.tsx
@@ -31,7 +31,10 @@ const MyInfoSettingsPage: CustomNextPage = () => {
   const { mutate: signOut, isLoading: isSigningOut } = useSignOut();
   const handleSignOut = () => {
     signOut(undefined, {
-      onSuccess: () => router.push(routes.main()),
+      onSuccess: () => {
+        closeModal();
+        router.push(routes.main());
+      },
       onError: (err) => handleAxiosError(err),
     });
   };

--- a/src/pages/profile/myinfo-settings/is-major/edit.tsx
+++ b/src/pages/profile/myinfo-settings/is-major/edit.tsx
@@ -1,21 +1,45 @@
+import type { MyInfoEditFormProps } from '~/components/Forms/MyInfoEditForm';
+
 import { useRouter } from 'next/router';
 
 import { css } from '@emotion/react';
+import { produce } from 'immer';
 
 import { DefaultFullPageLoader } from '~/components/Common';
 import MyInfoEditForm from '~/components/Forms/MyInfoEditForm';
-import { useMyInfo } from '~/services/member';
+import { useMyInfo, useSetMyInfo, useUpdateIsMajor } from '~/services/member';
 import { flex, titleBarHeight } from '~/styles/utils';
-import { routes } from '~/utils';
+import { handleAxiosError, routes } from '~/utils';
 
 const MyInfoSettingsIsMajorEditPage = () => {
   const router = useRouter();
   const { data: myInfo } = useMyInfo();
+  const { mutateAsync: updateIsMajor } = useUpdateIsMajor();
+  const setMyInfo = useSetMyInfo();
 
   if (!myInfo) {
     router.replace(routes.unauthorized());
     return <DefaultFullPageLoader />;
   }
+
+  const setIsMajor = (isMajor: boolean) => {
+    setMyInfo(
+      produce(myInfo, (draft) => {
+        draft.isMajor = isMajor;
+      })
+    );
+  };
+
+  const onValidSubmit: MyInfoEditFormProps['onValidSubmit'] = async (value) => {
+    const newIsMajor = value.isMajor;
+    try {
+      await updateIsMajor({ isMajor: newIsMajor });
+      setIsMajor(newIsMajor);
+      await router.push(routes.profile.myInfoSettings());
+    } catch (err) {
+      handleAxiosError(err);
+    }
+  };
 
   return (
     <div css={selfCss}>
@@ -25,9 +49,7 @@ const MyInfoSettingsIsMajorEditPage = () => {
         defaultValues={{
           isMajor: myInfo.isMajor,
         }}
-        onValidSubmit={(v) => {
-          console.log(v);
-        }}
+        onValidSubmit={onValidSubmit}
       />
     </div>
   );

--- a/src/pages/profile/myinfo-settings/is-major/edit.tsx
+++ b/src/pages/profile/myinfo-settings/is-major/edit.tsx
@@ -1,0 +1,53 @@
+import { useRouter } from 'next/router';
+
+import { css } from '@emotion/react';
+
+import { DefaultFullPageLoader } from '~/components/Common';
+import MyInfoEditForm from '~/components/Forms/MyInfoEditForm';
+import { useMyInfo } from '~/services/member';
+import { flex, titleBarHeight } from '~/styles/utils';
+import { routes } from '~/utils';
+
+interface MyInfoSettingsIsMajorEditPageProps {}
+
+const MyInfoSettingsIsMajorEditPage = (
+  props: MyInfoSettingsIsMajorEditPageProps
+) => {
+  const router = useRouter();
+  const { data: myInfo } = useMyInfo();
+
+  if (!myInfo) {
+    router.replace(routes.unauthorized());
+    return <DefaultFullPageLoader />;
+  }
+
+  return (
+    <div css={selfCss}>
+      <div css={{ marginBottom: 40 }} />
+      <MyInfoEditForm
+        css={formCss}
+        field="isMajor"
+        defaultValues={{
+          isMajor: myInfo.isMajor,
+        }}
+        onValidSubmit={(v) => {
+          console.log(v);
+        }}
+      />
+    </div>
+  );
+};
+
+export default MyInfoSettingsIsMajorEditPage;
+MyInfoSettingsIsMajorEditPage.auth = {
+  role: 'user',
+  loading: <DefaultFullPageLoader />,
+  unauthorized: routes.unauthorized(),
+};
+
+const selfCss = css(
+  { padding: `${titleBarHeight}px 15px`, height: '100vh' },
+  flex()
+);
+
+const formCss = css({ flexGrow: 1 });

--- a/src/pages/profile/myinfo-settings/is-major/edit.tsx
+++ b/src/pages/profile/myinfo-settings/is-major/edit.tsx
@@ -23,7 +23,6 @@ const MyInfoSettingsIsMajorEditPage = (
 
   return (
     <div css={selfCss}>
-      <div css={{ marginBottom: 40 }} />
       <MyInfoEditForm
         css={formCss}
         field="isMajor"
@@ -50,4 +49,4 @@ const selfCss = css(
   flex()
 );
 
-const formCss = css({ flexGrow: 1 });
+const formCss = css({ flexGrow: 1, padding: '60px 0 30px' });

--- a/src/pages/profile/myinfo-settings/is-major/edit.tsx
+++ b/src/pages/profile/myinfo-settings/is-major/edit.tsx
@@ -8,11 +8,7 @@ import { useMyInfo } from '~/services/member';
 import { flex, titleBarHeight } from '~/styles/utils';
 import { routes } from '~/utils';
 
-interface MyInfoSettingsIsMajorEditPageProps {}
-
-const MyInfoSettingsIsMajorEditPage = (
-  props: MyInfoSettingsIsMajorEditPageProps
-) => {
+const MyInfoSettingsIsMajorEditPage = () => {
   const router = useRouter();
   const { data: myInfo } = useMyInfo();
 

--- a/src/pages/profile/myinfo-settings/nickname/edit.tsx
+++ b/src/pages/profile/myinfo-settings/nickname/edit.tsx
@@ -1,23 +1,49 @@
 import type { CustomNextPage } from 'next/types';
+import type { MyInfoEditFormProps } from '~/components/Forms/MyInfoEditForm';
 
 import { useRouter } from 'next/router';
 
 import { css } from '@emotion/react';
+import { produce } from 'immer';
 
 import { DefaultFullPageLoader } from '~/components/Common';
 import MyInfoEditForm from '~/components/Forms/MyInfoEditForm';
-import { useMyInfo } from '~/services/member';
+import { useMyInfo, useSetMyInfo, useUpdateNickname } from '~/services/member';
 import { flex, titleBarHeight } from '~/styles/utils';
-import { routes } from '~/utils';
+import { handleAxiosError, routes } from '~/utils';
 
 const MyInfoSettingsNicknameEditPage: CustomNextPage = () => {
   const router = useRouter();
   const { data: myInfo } = useMyInfo();
+  const { mutateAsync: updateNickname } = useUpdateNickname();
+  const setMyInfo = useSetMyInfo();
 
-  if (!myInfo) {
+  if (!myInfo || !myInfo.nickname) {
     router.replace(routes.unauthorized());
     return <DefaultFullPageLoader />;
   }
+
+  const setNickname = (newNickname: string) => {
+    setMyInfo(
+      produce(myInfo, (draft) => {
+        draft.nickname = newNickname;
+      })
+    );
+  };
+
+  const onValidSubmit: MyInfoEditFormProps['onValidSubmit'] = async (value) => {
+    const newNickname = value.nickname;
+    try {
+      await updateNickname({
+        nickname: newNickname,
+      });
+
+      setNickname(newNickname);
+      await router.push(routes.profile.myInfoSettings());
+    } catch (err) {
+      handleAxiosError(err);
+    }
+  };
 
   return (
     <div css={selfCss}>
@@ -27,9 +53,7 @@ const MyInfoSettingsNicknameEditPage: CustomNextPage = () => {
         defaultValues={{
           nickname: myInfo.nickname,
         }}
-        onValidSubmit={(v) => {
-          console.log(v);
-        }}
+        onValidSubmit={onValidSubmit}
       />
     </div>
   );
@@ -48,4 +72,3 @@ const selfCss = css(
 );
 
 const formCss = css({ flexGrow: 1, padding: '60px 0 30px' });
-

--- a/src/pages/profile/myinfo-settings/nickname/edit.tsx
+++ b/src/pages/profile/myinfo-settings/nickname/edit.tsx
@@ -21,7 +21,6 @@ const MyInfoSettingsNicknameEditPage: CustomNextPage = () => {
 
   return (
     <div css={selfCss}>
-      <div css={{ marginBottom: 40 }} />
       <MyInfoEditForm
         css={formCss}
         field="nickname"
@@ -48,4 +47,5 @@ const selfCss = css(
   flex()
 );
 
-const formCss = css({ flexGrow: 1 });
+const formCss = css({ flexGrow: 1, padding: '60px 0 30px' });
+

--- a/src/pages/profile/myinfo-settings/ssafy-basic-info/edit.tsx
+++ b/src/pages/profile/myinfo-settings/ssafy-basic-info/edit.tsx
@@ -21,7 +21,6 @@ const MyInfoSettingsSsafyBasicInfoEditPage: CustomNextPage = () => {
 
   return (
     <div css={selfCss}>
-      <div css={{ marginBottom: 40 }} />
       <MyInfoEditForm
         css={formCss}
         field="ssafyBasicInfo"
@@ -52,4 +51,5 @@ const selfCss = css(
   flex()
 );
 
-const formCss = css({ flexGrow: 1 });
+const formCss = css({ flexGrow: 1, padding: '60px 0 30px' });
+

--- a/src/pages/profile/myinfo-settings/ssafy-basic-info/edit.tsx
+++ b/src/pages/profile/myinfo-settings/ssafy-basic-info/edit.tsx
@@ -3,6 +3,7 @@ import type { CustomNextPage } from 'next/types';
 import { useRouter } from 'next/router';
 
 import { css } from '@emotion/react';
+import { isBoolean } from 'is-what';
 
 import { DefaultFullPageLoader } from '~/components/Common';
 import MyInfoEditForm from '~/components/Forms/MyInfoEditForm';
@@ -14,7 +15,7 @@ const MyInfoSettingsSsafyBasicInfoEditPage: CustomNextPage = () => {
   const router = useRouter();
   const { data: myInfo } = useMyInfo();
 
-  if (!myInfo) {
+  if (!myInfo || !isBoolean(myInfo.ssafyMember)) {
     router.replace(routes.unauthorized());
     return <DefaultFullPageLoader />;
   }
@@ -28,7 +29,7 @@ const MyInfoSettingsSsafyBasicInfoEditPage: CustomNextPage = () => {
           ssafyBasicInfo: {
             campus: myInfo.ssafyInfo?.campus,
             year: myInfo.ssafyInfo?.semester,
-            ssafyMember: myInfo.ssafyMember ?? undefined,
+            ssafyMember: myInfo.ssafyMember,
           },
         }}
         onValidSubmit={(v) => {
@@ -52,4 +53,3 @@ const selfCss = css(
 );
 
 const formCss = css({ flexGrow: 1, padding: '60px 0 30px' });
-

--- a/src/pages/profile/myinfo-settings/ssafy-basic-info/edit.tsx
+++ b/src/pages/profile/myinfo-settings/ssafy-basic-info/edit.tsx
@@ -1,24 +1,77 @@
 import type { CustomNextPage } from 'next/types';
+import type { MyInfoEditFormProps } from '~/components/Forms/MyInfoEditForm';
 
 import { useRouter } from 'next/router';
 
 import { css } from '@emotion/react';
+import { produce } from 'immer';
 import { isBoolean } from 'is-what';
 
 import { DefaultFullPageLoader } from '~/components/Common';
 import MyInfoEditForm from '~/components/Forms/MyInfoEditForm';
-import { useMyInfo } from '~/services/member';
+import {
+  CertificationState,
+  useMyInfo,
+  useSetMyInfo,
+  useUpdateSsafyBasicInfo,
+} from '~/services/member';
 import { flex, titleBarHeight } from '~/styles/utils';
-import { routes } from '~/utils';
+import { customToast, handleAxiosError, routes } from '~/utils';
 
 const MyInfoSettingsSsafyBasicInfoEditPage: CustomNextPage = () => {
   const router = useRouter();
   const { data: myInfo } = useMyInfo();
+  const { mutateAsync: updateSsafyBasicInfo } = useUpdateSsafyBasicInfo();
+  const setMyInfo = useSetMyInfo();
+  const isCertified =
+    myInfo?.ssafyInfo?.certificationState === CertificationState.CERTIFIED;
 
   if (!myInfo || !isBoolean(myInfo.ssafyMember)) {
     router.replace(routes.unauthorized());
     return <DefaultFullPageLoader />;
   }
+
+  const onValidSubmit: MyInfoEditFormProps['onValidSubmit'] = async (value) => {
+    const { year: semester, ...restSsafyBasicInfo } = value.ssafyBasicInfo;
+    const newSsafyBasicInfo = {
+      semester,
+      ...restSsafyBasicInfo,
+    };
+
+    try {
+      await updateSsafyBasicInfo(newSsafyBasicInfo);
+
+      setMyInfo(
+        produce(myInfo, (draft) => {
+          draft.ssafyMember = newSsafyBasicInfo.ssafyMember;
+
+          if (draft.ssafyMember) {
+            draft.ssafyInfo = {
+              // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+              // @ts-ignore
+              certificationState: CertificationState.UNCERTIFIED,
+              majorTrack: null,
+              ...draft.ssafyInfo,
+              campus: newSsafyBasicInfo.campus,
+              semester: newSsafyBasicInfo.semester,
+            };
+          } else {
+            delete draft.ssafyInfo;
+          }
+        })
+      );
+      await router.push(routes.profile.myInfoSettings());
+    } catch (err) {
+      handleAxiosError(err);
+    }
+  };
+
+  const onInvalidSubmit: MyInfoEditFormProps['onInvalidSubmit'] = (errors) => {
+    const { ssafyBasicInfo: { campus, ssafyMember, year } = {} } = errors;
+
+    const message = ssafyMember?.message || campus?.message || year?.message;
+    customToast.clientError(message || '유효하지 않은 입력입니다.');
+  };
 
   return (
     <div css={selfCss}>
@@ -32,8 +85,10 @@ const MyInfoSettingsSsafyBasicInfoEditPage: CustomNextPage = () => {
             ssafyMember: myInfo.ssafyMember,
           },
         }}
-        onValidSubmit={(v) => {
-          console.log(v);
+        onValidSubmit={onValidSubmit}
+        onInvalidSubmit={onInvalidSubmit}
+        options={{
+          forceSsafyMemberToTrue: isCertified,
         }}
       />
     </div>

--- a/src/pages/profile/myinfo-settings/track/edit.tsx
+++ b/src/pages/profile/myinfo-settings/track/edit.tsx
@@ -1,0 +1,54 @@
+import type { CustomNextPage } from 'next/types';
+
+import { useRouter } from 'next/router';
+
+import { css } from '@emotion/react';
+
+import { DefaultFullPageLoader } from '~/components/Common';
+import MyInfoEditForm from '~/components/Forms/MyInfoEditForm';
+import { CertificationState, useMyInfo } from '~/services/member';
+import { flex, titleBarHeight } from '~/styles/utils';
+import { routes } from '~/utils';
+
+const MyInfoSettingsTrackEditPage: CustomNextPage = () => {
+  const router = useRouter();
+  const { data: myInfo } = useMyInfo();
+
+  if (
+    !myInfo ||
+    myInfo.ssafyInfo?.certificationState !== CertificationState.CERTIFIED
+  ) {
+    router.replace(routes.unauthorized());
+    return <DefaultFullPageLoader />;
+  }
+
+  return (
+    <div css={selfCss}>
+      <div css={{ marginBottom: 40 }} />
+      <MyInfoEditForm
+        css={formCss}
+        field="track"
+        defaultValues={{
+          track: myInfo.ssafyInfo.majorTrack,
+        }}
+        onValidSubmit={(v) => {
+          console.log(v);
+        }}
+      />
+    </div>
+  );
+};
+
+MyInfoSettingsTrackEditPage.auth = {
+  role: 'user',
+  loading: <DefaultFullPageLoader />,
+  unauthorized: routes.unauthorized(),
+};
+export default MyInfoSettingsTrackEditPage;
+
+const selfCss = css(
+  { padding: `${titleBarHeight}px 15px`, height: '100vh' },
+  flex()
+);
+
+const formCss = css({ flexGrow: 1 });

--- a/src/pages/profile/myinfo-settings/track/edit.tsx
+++ b/src/pages/profile/myinfo-settings/track/edit.tsx
@@ -24,7 +24,6 @@ const MyInfoSettingsTrackEditPage: CustomNextPage = () => {
 
   return (
     <div css={selfCss}>
-      <div css={{ marginBottom: 40 }} />
       <MyInfoEditForm
         css={formCss}
         field="track"
@@ -51,4 +50,4 @@ const selfCss = css(
   flex()
 );
 
-const formCss = css({ flexGrow: 1 });
+const formCss = css({ flexGrow: 1, padding: '60px 0 30px' });

--- a/src/services/member/apis.ts
+++ b/src/services/member/apis.ts
@@ -30,13 +30,13 @@ export const updateMyInfo = (params: UpdateMyInfoParams) => {
     .then((res) => res.data.data);
 };
 
-export interface UpdateSsafyInfoParams {
+export interface UpdateSsafyBasicInfoParams {
   ssafyMember: boolean;
   semester: null | number;
   campus: null | string;
 }
 
-export const updateSsafyInfo = (params: UpdateSsafyInfoParams) => {
+export const updateSsafyBasicInfo = (params: UpdateSsafyBasicInfoParams) => {
   const endpoint = endpoints.user.ssafyBasicInfo();
 
   return privateAxios.patch(endpoint, params).then((res) => res.data);

--- a/src/services/member/hooks.ts
+++ b/src/services/member/hooks.ts
@@ -11,7 +11,11 @@ import { routes } from '~/utils/routes';
 import {
   certifyStudent,
   getMyInfo,
+  updateIsMajor,
   updateMyInfo,
+  updateNickname,
+  updateSsafyBasicInfo,
+  updateTrack,
   validateNickname,
 } from './apis';
 
@@ -89,6 +93,30 @@ export const useCheckRegisterRequired = () => {
 export const useUpdateMyInfo = () => {
   return useMutation({
     mutationFn: updateMyInfo,
+  });
+};
+
+export const useUpdateNickname = () => {
+  return useMutation({
+    mutationFn: updateNickname,
+  });
+};
+
+export const useUpdateIsMajor = () => {
+  return useMutation({
+    mutationFn: updateIsMajor,
+  });
+};
+
+export const useUpdateSsafyBasicInfo = () => {
+  return useMutation({
+    mutationFn: updateSsafyBasicInfo,
+  });
+};
+
+export const useUpdateTrack = () => {
+  return useMutation({
+    mutationFn: updateTrack,
   });
 };
 

--- a/src/services/member/utils/extractNumericText.ts
+++ b/src/services/member/utils/extractNumericText.ts
@@ -1,0 +1,1 @@
+export const extractNumericText = (value: string) => value.replace(/\D/g, '');

--- a/src/services/member/utils/index.ts
+++ b/src/services/member/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './createRandomNickname';
+export * from './extractNumericText';
 export * from './nicknameValidator';
 export * from './role';
 export * from './types';

--- a/src/services/member/utils/nicknameValidator.ts
+++ b/src/services/member/utils/nicknameValidator.ts
@@ -11,7 +11,11 @@ const isValidFormat = (value: string) => {
   return !/[^\w 가-힣]/.test(value);
 };
 
-export const nicknameValidator = (value: string) => {
+export const nicknameValidator = (value: string, initialNickname: string) => {
+  if (value === initialNickname) {
+    return false;
+  }
+
   if (!isValidLength(value)) {
     return '길이는 1 ~ 11 사이여야 합니다.';
   }

--- a/src/services/meta/hooks.ts
+++ b/src/services/meta/hooks.ts
@@ -13,7 +13,7 @@ export const initialCampuses = [
 ];
 
 export const useCampuses = () => {
-  const { data } = useQuery({
+  return useQuery({
     queryKey: queryKeys.meta.campuses(),
     queryFn: getCampuses,
     initialData: initialCampuses,
@@ -23,8 +23,6 @@ export const useCampuses = () => {
         .map(({ name }) => name);
     },
   });
-
-  return data;
 };
 
 export const useTracks = () => {

--- a/src/stories/MyInfoSettingsPage.stories.tsx
+++ b/src/stories/MyInfoSettingsPage.stories.tsx
@@ -1,10 +1,14 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
+import { useEffect } from 'react';
+
+import { userInfo } from '~/mocks/handlers/member/data';
 import MyInfoSettingsPage from '~/pages/profile/myinfo-settings';
+import { useSetMyInfo } from '~/services/member';
 import { PageLayout } from '~/stories/Layout';
 
 const meta: Meta<typeof MyInfoSettingsPage> = {
-  title: 'Page/MyInfoSettings',
+  title: 'Page/MyInfoSettings/Root',
   component: MyInfoSettingsPage,
   decorators: [
     (Story) => (
@@ -15,6 +19,12 @@ const meta: Meta<typeof MyInfoSettingsPage> = {
   ],
   parameters: {
     layout: 'fullscreen',
+
+    msw: {
+      handlers: {
+        member: [],
+      },
+    },
   },
 };
 
@@ -22,4 +32,41 @@ export default meta;
 
 type MyInfoSettingsPageStory = StoryObj<typeof MyInfoSettingsPage>;
 
-export const Default: MyInfoSettingsPageStory = {};
+export const NonSsafyUser: MyInfoSettingsPageStory = {
+  decorators: [
+    (Story) => {
+      const setMyInfo = useSetMyInfo();
+      useEffect(() => {
+        setMyInfo(userInfo.nonSsafyUserInfo);
+      }, [setMyInfo]);
+
+      return <Story />;
+    },
+  ],
+};
+
+export const UnCertifiedSsafyUser: MyInfoSettingsPageStory = {
+  decorators: [
+    (Story) => {
+      const setMyInfo = useSetMyInfo();
+      useEffect(() => {
+        setMyInfo(userInfo.uncertifiedSsafyUserInfo);
+      }, [setMyInfo]);
+
+      return <Story />;
+    },
+  ],
+};
+
+export const CertifiedSsafyUser: MyInfoSettingsPageStory = {
+  decorators: [
+    (Story) => {
+      const setMyInfo = useSetMyInfo();
+      useEffect(() => {
+        setMyInfo(userInfo.certifiedSsafyUserInfo);
+      }, [setMyInfo]);
+
+      return <Story />;
+    },
+  ],
+};

--- a/src/stories/SsafyBasicInfoEditPage.stories.tsx
+++ b/src/stories/SsafyBasicInfoEditPage.stories.tsx
@@ -1,0 +1,117 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { expect } from '@storybook/jest';
+import { userEvent, within } from '@storybook/testing-library';
+import { useEffect } from 'react';
+
+import { userInfo } from '~/mocks/handlers/member/data';
+import MyInfoSettingsSsafyBasicInfoEditPage from '~/pages/profile/myinfo-settings/ssafy-basic-info/edit';
+import { useSetMyInfo } from '~/services/member';
+import { PageLayout } from '~/stories/Layout';
+import { sleep } from '~/utils';
+
+const meta: Meta<typeof MyInfoSettingsSsafyBasicInfoEditPage> = {
+  title: 'Page/MyInfoSettings/SsafyBasicInfoEdit',
+  component: MyInfoSettingsSsafyBasicInfoEditPage,
+  decorators: [
+    (Story) => (
+      <PageLayout>
+        <Story />
+      </PageLayout>
+    ),
+  ],
+  parameters: {
+    layout: 'fullscreen',
+
+    msw: {
+      handlers: {
+        member: [],
+      },
+    },
+  },
+};
+
+export default meta;
+
+type SsafyBasicInfoEditPageStory = StoryObj<
+  typeof MyInfoSettingsSsafyBasicInfoEditPage
+>;
+
+export const UnCertifiedSsafyUser: SsafyBasicInfoEditPageStory = {
+  decorators: [
+    (Story) => {
+      const setMyInfo = useSetMyInfo();
+      useEffect(() => {
+        setMyInfo(userInfo.uncertifiedSsafyUserInfo);
+      }, [setMyInfo]);
+
+      return <Story />;
+    },
+  ],
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    await sleep(500);
+
+    const ssafyMemberSelectBox = await canvas.findByRole('combobox', {
+      name: 'SSAFY인 여부',
+    });
+    const yearSelectBox = await canvas.findByRole('combobox', {
+      name: 'SSAFY 기수 선택',
+    });
+    const campusSelectBox = await canvas.findByRole('combobox', {
+      name: 'SSAFY 캠퍼스 선택',
+    });
+
+    await step(
+      'SSAFY인 여부를 "아니오"로 바꾸면, SSAFY 기수 선택, SSAFY 캠퍼스 선택 SelectBox가 비활성화 된다.',
+      async () => {
+        await userEvent.click(ssafyMemberSelectBox);
+        const noOption = canvas.getByRole('option', { name: '아니오' });
+        await userEvent.click(noOption);
+
+        expect(yearSelectBox).toBeDisabled();
+        expect(campusSelectBox).toBeDisabled();
+      }
+    );
+
+    await step(
+      'SSAFY인 여부를 "예"로 바꾸면, SSAFY 기수 선택, SSAFY 캠퍼스 선택 SelectBox가 활성화 된다.',
+      async () => {
+        await userEvent.click(ssafyMemberSelectBox);
+        const yesOption = canvas.getByRole('option', { name: '네' });
+        await userEvent.click(yesOption);
+
+        expect(yearSelectBox).toBeEnabled();
+        expect(campusSelectBox).toBeEnabled();
+      }
+    );
+  },
+};
+
+export const CertifiedSsafyUser: SsafyBasicInfoEditPageStory = {
+  decorators: [
+    (Story) => {
+      const setMyInfo = useSetMyInfo();
+      useEffect(() => {
+        setMyInfo(userInfo.certifiedSsafyUserInfo);
+      }, [setMyInfo]);
+
+      return <Story />;
+    },
+  ],
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    await sleep(500);
+
+    const ssafyMemberSelectBox = await canvas.findByRole('combobox', {
+      name: 'SSAFY인 여부',
+    });
+
+    await step(
+      'SSAFY 학생 인증된 사용자는, SSAFY인 여부를 바꿀 수 없다.',
+      async () => {
+        expect(ssafyMemberSelectBox).toBeDisabled();
+      }
+    );
+  },
+};

--- a/src/utils/handleAxiosError.tsx
+++ b/src/utils/handleAxiosError.tsx
@@ -4,6 +4,7 @@ import { isAxiosError } from 'axios';
 import toast from 'react-hot-toast';
 
 import { Toast } from '~/components/Common';
+import { customToast } from '~/utils';
 
 interface HandleAxiosErrorOptions {
   /**
@@ -24,7 +25,7 @@ interface HandleAxiosErrorOptions {
   /**
    * - `statusCode`값이 `400 ~ 499` (=클라이언트 오류)일 때 수행할 함수입니다.
    */
-  onClientError: (response: ApiErrorResponse) => void;
+  onClientError: ((response: ApiErrorResponse) => void) | null;
   /**
    * - `statusCode`값이 `500 ~ 599` (=서버 오류)일 때 수행할 함수입니다.
    * - 주어지지 않으면 기본 핸들러 함수를 사용합니다.
@@ -44,7 +45,7 @@ export const handleAxiosError = (
     tag = '',
     clientMessageOnServerError = '서버에서 알 수 없는 오류가 발생하였습니다',
     showServerMessage = process.env.NODE_ENV === 'development',
-    onClientError,
+    onClientError = defaultOnClientError,
     onServerError,
     skipServerError = false,
   } = options;
@@ -79,4 +80,10 @@ export const handleAxiosError = (
   if (400 <= statusCode && statusCode < 500) {
     onClientError?.(error.response.data);
   }
+};
+
+const defaultOnClientError: HandleAxiosErrorOptions['onClientError'] = (
+  err
+) => {
+  customToast.clientError(err.message || '오류가 발생했습니다');
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -11850,6 +11850,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"immer@npm:^10.0.2":
+  version: 10.0.2
+  resolution: "immer@npm:10.0.2"
+  checksum: 525a3b14210d02ae420c3b9f6ca14f7e9bcf625611d1356e773e7739f14c7c8de50dac442e6c7de3a6e24a782f7b792b6b8666bc0b3f00269d21a95f8f68ca84
+  languageName: node
+  linkType: hard
+
 "import-fresh@npm:^3.0.0, import-fresh@npm:^3.2.1":
   version: 3.3.0
   resolution: "import-fresh@npm:3.3.0"
@@ -17697,6 +17704,7 @@ __metadata:
     eslint-config-prettier: ^8.8.0
     eslint-plugin-import: ^2.27.5
     eslint-plugin-storybook: ^0.6.12
+    immer: ^10.0.2
     is-what: ^4.1.15
     jest: ^29.5.0
     jest-environment-jsdom: ^29.5.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -17718,6 +17718,7 @@ __metadata:
     react-zoom-pan-pinch: ^3.1.0
     storybook: ^7.0.27
     tsconfig-paths-webpack-plugin: ^4.0.1
+    type-fest: ^4.0.0
     typescript: 5.0.4
     unique-names-generator: ^4.7.1
   languageName: unknown
@@ -18610,6 +18611,13 @@ __metadata:
   peerDependencies:
     typescript: ">=4.7.0"
   checksum: df3bd25809ea79ac7712da7c11648251118c23f65b226eba263797e42be60ba34085874ec492202b8ecf2e5a2273b27ddcbfe3be2c275dfcef3f0e2ee90ea179
+  languageName: node
+  linkType: hard
+
+"type-fest@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "type-fest@npm:4.0.0"
+  checksum: 716f32ac341b1cf35bf08cc5cc6a11822436333966d3f4d94758112f45829efa3efb643ebc74a53e514e68a1bddab144d0153d654e072b41ba9bd98bcf841d75
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Issues

- #118 

<!-- 이슈 번호를 작성해주세요. 여러 이슈 번호를 작성해도 됩니다. -->

## 구분

- [ ] 버그 수정
- [x] 기능 추가
- [x] 코드 리팩터링
- [ ] 문서 업데이트
- [ ] 기타

<!-- 어떤 이유로 코드를 변경했는지 체크해주세요. -->

## 주요 변경점

- 내 프로필 세팅 페이지
   - `UserRegisterForm`의 닉네임 필드를 재활용 가능하게 변경 (prop등을 추가, 유틸 함수를 분리)
   - 내정보 수정 기능 (닉네임, 트랙, 싸피정보, 전공자여부)
   - 로그아웃

- 프로필 공개여부 토글은 저와 태용님이 잘못 이해한 부분이 있어서 그 부분 API 명세 고친 후에 추가해야해서, 아직 작업 진행중입니다.
   - 프로필 공개 여부 토글만 추가되면, 내 프로필 세팅 페이지도 기능 구현이 끝납니다.

<!-- 주요 변경점과 어떤 부분을 집중해서 리뷰해야 하는지 알려주세요. -->

## 스크린샷


<!-- 관련 미디어 파일이 있으면 첨부해주세요. -->

## 기타

<!-- 추가로 전달할 내용, 메모할 내용, 테스트 계획, 완료된 테스트 등을 알려주세요. -->

