### PR TITLE
내정보 수정 4 (마지막)

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,6 +1,7 @@
 import type { Preview } from '@storybook/react';
 import { Global, css } from '@emotion/react';
 import { initialize, mswLoader } from 'msw-storybook-addon';
+import 'react-loading-skeleton/dist/skeleton.css';
 
 import AppGlobalStyles from '../src/styles/GlobalStyles';
 import {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "react-hook-form": "^7.45.0",
     "react-hot-toast": "^2.4.1",
     "react-icons": "^4.9.0",
+    "react-loading-skeleton": "^3.3.1",
     "react-quill": "^2.0.0",
     "react-spinners": "^0.13.8",
     "react-zoom-pan-pinch": "^3.1.0",

--- a/src/components/Common/Toast/ServerErrorToast.tsx
+++ b/src/components/Common/Toast/ServerErrorToast.tsx
@@ -1,10 +1,11 @@
 import type { Toast } from 'react-hot-toast';
 
-import { css } from '@emotion/react';
 import toast from 'react-hot-toast';
 
 import { Icon } from '~/components/Common';
-import { flex, fontCss, palettes } from '~/styles/utils';
+import { palettes } from '~/styles/utils';
+
+import ToastRoot from './ToastRoot';
 
 interface ServerErrorToastProps {
   t: Toast;
@@ -24,35 +25,14 @@ const ServerErrorToast = (props: ServerErrorToastProps) => {
   const shouldShowServerMessage = showServerMessage && serverMessage;
 
   return (
-    <div css={selfCss} onClick={() => toast.dismiss(t.id)}>
-      <div css={flex('center')}>
-        <Icon name="close" color={palettes.error.default} size={24} />
-      </div>
-      <div>
-        {clientMessage && <p>{clientMessage}</p>}
-        {shouldShowServerMessage && <p>{serverMessage}</p>}
-      </div>
-    </div>
+    <ToastRoot
+      icon={<Icon name="close" color={palettes.error.default} size={24} />}
+      onClick={() => toast.dismiss(t.id)}
+    >
+      {clientMessage && <p>{clientMessage}</p>}
+      {shouldShowServerMessage && <p>{serverMessage}</p>}
+    </ToastRoot>
   );
 };
 
 export default ServerErrorToast;
-
-const selfCss = css(
-  {
-    cursor: 'pointer',
-    transition: 'transform 200ms',
-    padding: 10,
-    paddingLeft: 6,
-    margin: '-4px -10px', // 기본 스타일때문에.
-    ':hover': {
-      transform: 'translate3d(0, -2px, 0)',
-    },
-    ':active': {
-      transform: 'translate3d(0, 2px, 0)',
-    },
-  },
-  fontCss.family.auto,
-  fontCss.style.B12,
-  flex('center', 'space-between', 'row', 8)
-);

--- a/src/components/Common/Toast/SuccessToast.tsx
+++ b/src/components/Common/Toast/SuccessToast.tsx
@@ -1,0 +1,28 @@
+import type { Toast } from 'react-hot-toast';
+
+import toast from 'react-hot-toast';
+
+import { Icon } from '~/components/Common';
+import ToastRoot from '~/components/Common/Toast/ToastRoot';
+import { palettes } from '~/styles/utils';
+
+interface SuccessToastProps {
+  t: Toast;
+  message: string;
+}
+
+const SuccessToast = (props: SuccessToastProps) => {
+  const { t, message } = props;
+  return (
+    <ToastRoot
+      onClick={() => {
+        toast.dismiss(t.id);
+      }}
+      icon={<Icon name="check" color={palettes.success.default} size={24} />}
+    >
+      {message}
+    </ToastRoot>
+  );
+};
+
+export default SuccessToast;

--- a/src/components/Common/Toast/Toast.stories.tsx
+++ b/src/components/Common/Toast/Toast.stories.tsx
@@ -3,6 +3,7 @@ import type { StoryObj, Meta } from '@storybook/react';
 import toast, { Toaster } from 'react-hot-toast';
 
 import { Button } from '~/components/Common';
+import SuccessToast from '~/components/Common/Toast/SuccessToast';
 
 import ServerErrorToast from './ServerErrorToast';
 
@@ -22,8 +23,7 @@ const meta: Meta = {
 export default meta;
 
 type ServerErrorToastStory = StoryObj<typeof ServerErrorToast>;
-export const Default: ServerErrorToastStory = {
-  name: 'ServerErrorToast',
+export const ServerError: ServerErrorToastStory = {
   args: {
     clientMessage: 'Client Error Message',
     serverMessage: 'Server Error Message',
@@ -34,6 +34,27 @@ export const Default: ServerErrorToastStory = {
 
     const onClick = () => {
       toast((t) => <ServerErrorToast t={t} {...rest} />);
+    };
+
+    return (
+      <div>
+        <Button onClick={onClick}>트리거 버튼</Button>
+      </div>
+    );
+  },
+};
+
+type SuccessToastStory = StoryObj<typeof SuccessToast>;
+
+export const Success: SuccessToastStory = {
+  args: {
+    message: 'Success',
+  },
+  render: (args) => {
+    const { t: _, ...rest } = args;
+
+    const onClick = () => {
+      toast((t) => <SuccessToast t={t} {...rest} />);
     };
 
     return (

--- a/src/components/Common/Toast/ToastRoot.tsx
+++ b/src/components/Common/Toast/ToastRoot.tsx
@@ -1,0 +1,44 @@
+import type { ComponentPropsWithoutRef, ReactNode } from 'react';
+
+import { css } from '@emotion/react';
+
+import { flex, fontCss } from '~/styles/utils';
+
+interface ToastRootProps extends ComponentPropsWithoutRef<'div'> {
+  children: ReactNode;
+  icon: ReactNode;
+}
+
+const ToastRoot = (props: ToastRootProps) => {
+  const { children, icon, ...restProps } = props;
+
+  return (
+    <div css={selfCss} {...restProps}>
+      <div css={iconLayerCss}>{icon}</div>
+      <div>{children}</div>
+    </div>
+  );
+};
+
+export default ToastRoot;
+
+const selfCss = css(
+  {
+    cursor: 'pointer',
+    transition: 'transform 200ms',
+    padding: 10,
+    paddingLeft: 6,
+    margin: '-4px -10px', // 기본 스타일때문에.
+    ':hover': {
+      transform: 'translate3d(0, -2px, 0)',
+    },
+    ':active': {
+      transform: 'translate3d(0, 2px, 0)',
+    },
+  },
+  fontCss.family.auto,
+  fontCss.style.B12,
+  flex('center', 'space-between', 'row', 8)
+);
+
+const iconLayerCss = css(flex('center'));

--- a/src/components/Common/Toast/index.tsx
+++ b/src/components/Common/Toast/index.tsx
@@ -1,7 +1,9 @@
 import ServerErrorToast from './ServerErrorToast';
+import SuccessToast from './SuccessToast';
 
 const Toast = {
   ServerError: ServerErrorToast,
+  Success: SuccessToast,
 };
 
 export default Toast;

--- a/src/components/Common/Toggle/index.tsx
+++ b/src/components/Common/Toggle/index.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import * as RadixToggle from '@radix-ui/react-toggle';
 
-import { inlineFlex, palettes, themeColorVars } from '~/styles/utils';
+import { colorMix, inlineFlex, palettes, themeColorVars } from '~/styles/utils';
 
 type ToggleTheme = 'primary' | 'secondary' | 'recruit';
 type ToggleOrder = 'thumb-first' | 'text-first';
@@ -67,9 +67,13 @@ const selfSizeCss = (
   padding: number | string
 ) =>
   css({
+    cursor: 'pointer',
     width: thumbSize + textWidth,
     height: thumbSize,
     padding,
+    '&:disabled': {
+      opacity: 0.5,
+    },
   });
 
 const thumbSizeCss = (

--- a/src/components/Forms/Common/Nickname/utils/index.ts
+++ b/src/components/Forms/Common/Nickname/utils/index.ts
@@ -1,1 +1,0 @@
-export * from './useNicknameReconfirmModal';

--- a/src/components/Forms/MyInfoEditForm/index.tsx
+++ b/src/components/Forms/MyInfoEditForm/index.tsx
@@ -23,6 +23,7 @@ const titleMap: Record<MyInfoEditFormFields, string> = {
 
 interface MyInfoEditFormPropsOptions {
   forceSsafyMemberToTrue: boolean;
+  titleBarBackwardRoute: string;
 }
 
 export interface MyInfoEditFormProps {
@@ -41,7 +42,7 @@ const MyInfoEditForm = (props: MyInfoEditFormProps) => {
     onValidSubmit,
     onInvalidSubmit,
     className,
-    options: { forceSsafyMemberToTrue } = {},
+    options: { forceSsafyMemberToTrue, titleBarBackwardRoute } = {},
   } = props;
 
   const methods = useForm<MyInfoEditFormValues>({
@@ -60,7 +61,11 @@ const MyInfoEditForm = (props: MyInfoEditFormProps) => {
         className={className}
         onSubmit={handleSubmit(onValidSubmit, onInvalidSubmit)}
       >
-        <TitleBar.Default title={titleMap[field]} withoutClose />
+        <TitleBar.Default
+          title={titleMap[field]}
+          backwardAs={titleBarBackwardRoute}
+          withoutClose
+        />
         {field === 'nickname' && (
           <Nickname
             buttonText="수정 완료"

--- a/src/components/Forms/MyInfoEditForm/index.tsx
+++ b/src/components/Forms/MyInfoEditForm/index.tsx
@@ -20,7 +20,7 @@ type MyInfoEditFormFields = keyof MyInfoEditFormValues;
 
 const titleMap: Record<MyInfoEditFormFields, string> = {
   nickname: '닉네임 수정',
-  isMajor: 'SSAFY 전공자',
+  isMajor: '전공자 여부',
   ssafyBasicInfo: 'SSAFY 기본정보',
   track: 'SSAFY 트랙',
 };

--- a/src/components/Forms/UserRegisterForm/Fields/Nickname/NicknameInput.tsx
+++ b/src/components/Forms/UserRegisterForm/Fields/Nickname/NicknameInput.tsx
@@ -8,14 +8,14 @@ import { AlertText, Icon, IconButton, TextInput } from '~/components/Common';
 import { createRandomNickname, nicknameValidator } from '~/services/member';
 import { flex } from '~/styles/utils';
 
-interface NicknameProps {
+interface NicknameInputProps {
   fieldName: string;
   initialNickname: string;
   className?: string;
   id?: string;
 }
 
-const Nickname = (props: NicknameProps) => {
+const NicknameInput = (props: NicknameInputProps) => {
   const { fieldName, className, id, initialNickname } = props;
   const { register, setFocus, setValue } = useFormContext();
 
@@ -59,7 +59,7 @@ const Nickname = (props: NicknameProps) => {
   );
 };
 
-Nickname.displayName = 'Nickname';
-export default Nickname;
+NicknameInput.displayName = 'Nickname';
+export default NicknameInput;
 
 const refreshNicknameCss = css(flex('center', 'flex-end', 'row', 8));

--- a/src/components/Forms/UserRegisterForm/Fields/Nickname/index.tsx
+++ b/src/components/Forms/UserRegisterForm/Fields/Nickname/index.tsx
@@ -3,13 +3,14 @@ import { useEffect, useId, useRef, useState } from 'react';
 import { useWatch } from 'react-hook-form';
 
 import { Button, VisuallyHidden } from '~/components/Common';
-import NicknameField from '~/components/Forms/Common/Nickname';
-import { useNicknameReconfirmModal } from '~/components/Forms/Common/Nickname/utils';
 import { useUserRegisterFormContext } from '~/components/Forms/UserRegisterForm/utils';
 import { useModal } from '~/components/GlobalModal';
 import { useValidateNickname } from '~/services/member';
 import { flex, fontCss } from '~/styles/utils';
 import { handleAxiosError } from '~/utils';
+
+import NicknameInput from './NicknameInput';
+import { useNicknameReconfirmModal } from './useNicknameReconfirmModal';
 
 const fieldName = 'nickname';
 
@@ -109,7 +110,7 @@ const Nickname = (props: NicknameProps) => {
         </label>
       )}
 
-      <NicknameField
+      <NicknameInput
         id={nicknameFieldId}
         initialNickname={initialNickname}
         css={inputContainerCss}

--- a/src/components/Forms/UserRegisterForm/Fields/Nickname/useNicknameReconfirmModal.tsx
+++ b/src/components/Forms/UserRegisterForm/Fields/Nickname/useNicknameReconfirmModal.tsx
@@ -1,10 +1,12 @@
 import { useModal } from '~/components/GlobalModal';
 import { palettes } from '~/styles/utils';
 
-interface DescriptionProps {
+interface NicknameReconfirmDescriptionProps {
   nickname: string;
 }
-const Description = (props: DescriptionProps) => {
+const NicknameReconfirmDescription = (
+  props: NicknameReconfirmDescriptionProps
+) => {
   const { nickname } = props;
   return (
     <p>
@@ -29,7 +31,7 @@ export const useNicknameReconfirmModal = () => {
 
     openModal('alert', {
       title: '알림',
-      description: <Description nickname={nickname} />,
+      description: <NicknameReconfirmDescription nickname={nickname} />,
       actionText: '확인',
       cancelText: '취소',
       onClickAction: onClickAction,

--- a/src/components/Layout/MainLayout.tsx
+++ b/src/components/Layout/MainLayout.tsx
@@ -2,7 +2,6 @@ import type { ReactNode } from 'react';
 
 import { css } from '@emotion/react';
 
-import NavigationGroup from '~/components/NavigationGroup';
 import { globalVars, pageMaxWidth, pageMinWidth } from '~/styles/utils';
 
 // 임시 레이아웃입니다.
@@ -11,14 +10,12 @@ import { globalVars, pageMaxWidth, pageMinWidth } from '~/styles/utils';
 interface MainLayoutProps {
   children: ReactNode;
   className?: string;
-  withNavigation?: boolean;
 }
 
 const MainLayout = (props: MainLayoutProps) => {
-  const { children, className, withNavigation = false } = props;
+  const { children, className } = props;
   return (
     <div css={selfCss} className={className}>
-      {withNavigation && <NavigationGroup />}
       <main>{children}</main>
     </div>
   );

--- a/src/components/Toggles/ProfileVisibilityToggle/ProfileVisibilityToggle.tsx
+++ b/src/components/Toggles/ProfileVisibilityToggle/ProfileVisibilityToggle.tsx
@@ -1,0 +1,28 @@
+import { Toggle } from '~/components/Common';
+import { fontCss } from '~/styles/utils';
+
+interface ProfileVisibilityToggle {
+  isPublic?: boolean;
+  disabled?: boolean;
+  onPressedChange?: (value: boolean) => void;
+}
+
+const ProfileVisibilityToggle = (props: ProfileVisibilityToggle) => {
+  const { isPublic = false, disabled = false, onPressedChange } = props;
+  const toggleText = isPublic ? '공개' : '비공개';
+
+  return (
+    <Toggle
+      disabled={disabled}
+      pressed={isPublic}
+      onPressedChange={onPressedChange}
+      padding="3px 5px"
+      thumbSize={20}
+      textWidth={40}
+      text={toggleText}
+      css={fontCss.style.B12}
+    />
+  );
+};
+
+export default ProfileVisibilityToggle;

--- a/src/components/Toggles/ProfileVisibilityToggle/ProfileVisibilityToggleSkeleton.tsx
+++ b/src/components/Toggles/ProfileVisibilityToggle/ProfileVisibilityToggleSkeleton.tsx
@@ -1,0 +1,24 @@
+import { css } from '@emotion/react';
+import Skeleton from 'react-loading-skeleton';
+
+import { inlineFlex, palettes } from '~/styles/utils';
+
+const ProfileVisibilityToggleSkeleton = () => {
+  return (
+    <Skeleton
+      borderRadius={16}
+      width={72}
+      height={27}
+      baseColor={palettes.background.grey}
+      highlightColor={palettes.font.blueGrey}
+      css={selfCss}
+    />
+  );
+};
+
+export default ProfileVisibilityToggleSkeleton;
+
+const selfCss = css(
+  { border: `1px solid ${palettes.font.blueGrey}` },
+  inlineFlex('center', 'center')
+);

--- a/src/components/Toggles/ProfileVisibilityToggle/index.ts
+++ b/src/components/Toggles/ProfileVisibilityToggle/index.ts
@@ -1,0 +1,6 @@
+import Toggle from './ProfileVisibilityToggle';
+import Skeleton from './ProfileVisibilityToggleSkeleton';
+
+export const ProfileVisibilityToggle = Object.assign(Toggle, {
+  Skeleton,
+});

--- a/src/components/Toggles/index.ts
+++ b/src/components/Toggles/index.ts
@@ -1,0 +1,1 @@
+export * from './ProfileVisibilityToggle';

--- a/src/mocks/handlers/member/data.ts
+++ b/src/mocks/handlers/member/data.ts
@@ -64,4 +64,6 @@ const privatePortfolio: UserPortfolio = {
 export const userPortfolio = {
   publicPortfolio,
   privatePortfolio,
+  myPublicPortfolio: publicPortfolio,
+  myPrivatePortfolio: { ...publicPortfolio, isPublic: false },
 };

--- a/src/mocks/handlers/member/data.ts
+++ b/src/mocks/handlers/member/data.ts
@@ -1,6 +1,7 @@
-import type { UserInfo } from '~/services/member';
+import type { UserInfo, UserPortfolio } from '~/services/member';
 
 import { CertificationState, SsafyTrack } from '~/services/member';
+import { SkillName } from '~/services/recruit';
 
 const initialUserInfo: UserInfo = {
   memberId: 434,
@@ -44,4 +45,23 @@ export const userInfo = {
   certifiedSsafyUserInfo,
   uncertifiedSsafyUserInfo,
   nonSsafyUserInfo,
+};
+
+const publicPortfolio: UserPortfolio = {
+  isPublic: true,
+  portfolio: {
+    selfIntroduction: 'grammar',
+    skills: Object.values(SkillName).slice(0, 10),
+    memberLinks: [],
+  },
+};
+
+const privatePortfolio: UserPortfolio = {
+  isPublic: false,
+  portfolio: null,
+};
+
+export const userPortfolio = {
+  publicPortfolio,
+  privatePortfolio,
 };

--- a/src/mocks/handlers/member/index.ts
+++ b/src/mocks/handlers/member/index.ts
@@ -1,6 +1,7 @@
 import type {
   CertifyStudentApiData,
   GetMyInfoApiData,
+  GetProfileVisibilityApiData,
   MyPortfolio,
   UpdateMyInfoParams,
   UserInfo,
@@ -16,17 +17,14 @@ import { endpoints } from '~/react-query/common';
 import { CertificationState } from '~/services/member';
 import { API_URL, composeUrls, ResponseCode } from '~/utils';
 
-const getMyInfo = rest.get<never, never, GetMyInfoApiData | ApiErrorResponse>(
+export const getMyInfo = restSuccess<GetMyInfoApiData['data']>(
+  'get',
   composeUrls(API_URL, endpoints.user.myInfo()),
-  (req, res, ctx) => {
-    return res(
-      ctx.delay(500),
-      // ...mockSuccess<UserInfo>(ctx, userInfo.initialUserInfo)
-      ...mockSuccess<UserInfo>(ctx, userInfo.certifiedSsafyUserInfo)
-      // ...mockSuccess<UserInfo>(ctx, userInfo.uncertifiedSsafyUserInfo)
-      // ...mockSuccess<UserInfo>(ctx, userInfo.nonSsafyUserInfo)
-      // ...mockError(ctx, 'code', 'message', 404),
-    );
+  {
+    // data: userInfo.initialUserInfo,
+    data: userInfo.certifiedSsafyUserInfo,
+    // data: userInfo.uncertifiedSsafyUserInfo,
+    // data: userInfo.nonSsafyUserInfo,
   }
 );
 
@@ -64,16 +62,10 @@ const updateMyInfo = rest.put<
   );
 });
 
-const validateNickname = rest.post(
+const validateNickname = restSuccess(
+  'post',
   composeUrls(API_URL, endpoints.user.nickname()),
-  (req, res, ctx) => {
-    return res(
-      ctx.delay(500),
-      ...mockSuccess(ctx, {})
-      // ...mockError(ctx, '400', '닉네임이 중복됩니다.'),
-      // ...mockError(ctx, '400', '닉네임의 길이는 1 ~ 11 사이여야 합니다..')
-    );
-  }
+  { data: null }
 );
 
 export const validateNicknameError = restError(
@@ -163,20 +155,25 @@ export const certifyStudentAttemptsCountError = restError(
   }
 );
 
-export const updatePortfolioVisibility = restSuccess(
+export const getProfileVisibility = restSuccess<
+  GetProfileVisibilityApiData['data']
+>('get', composeUrls(API_URL, endpoints.user.profileVisibility()), {
+  data: {
+    isPublic: true,
+    // isPublic: false,
+  },
+});
+
+export const updateProfileVisibility = restSuccess(
   'patch',
-  composeUrls(API_URL, endpoints.user.portfolioVisibility()),
-  {
-    data: null,
-  }
+  composeUrls(API_URL, endpoints.user.profileVisibility()),
+  { data: null }
 );
 
-export const updatePortfolioVisibilityError = restError(
+export const updateProfileVisibilityError = restError(
   'patch',
-  composeUrls(API_URL, endpoints.user.portfolioVisibility()),
-  {
-    message: '에러가 발생했습니다',
-  }
+  composeUrls(API_URL, endpoints.user.profileVisibility()),
+  { message: '에러가 발생했습니다' }
 );
 
 export const getPortfolio = restSuccess<UserPortfolio>(
@@ -208,7 +205,8 @@ export const memberHandlers = [
   updateIsMajor,
   updateSsafyBasicInfo,
   updateTrack,
-  updatePortfolioVisibility,
+  getProfileVisibility,
+  updateProfileVisibility,
   getPortfolio,
   getMyPortfolio,
 ];

--- a/src/mocks/handlers/member/index.ts
+++ b/src/mocks/handlers/member/index.ts
@@ -3,12 +3,13 @@ import type {
   GetMyInfoApiData,
   UpdateMyInfoParams,
   UserInfo,
+  UserPortfolio,
 } from '~/services/member';
 import type { ApiErrorResponse } from '~/types';
 
 import { rest } from 'msw';
 
-import { userInfo } from '~/mocks/handlers/member/data';
+import { userInfo, userPortfolio } from '~/mocks/handlers/member/data';
 import { mockSuccess, restError, restSuccess } from '~/mocks/utils';
 import { endpoints } from '~/react-query/common';
 import { CertificationState } from '~/services/member';
@@ -177,6 +178,17 @@ export const updatePortfolioVisibilityError = restError(
   }
 );
 
+export const getPortfolio = restSuccess<UserPortfolio>(
+  'get',
+  // eslint-disable-next-line
+  // @ts-ignore
+  composeUrls(API_URL, endpoints.user.portfolio(':id')),
+  {
+    data: userPortfolio.publicPortfolio,
+    // data: userPortfolio.privatePortfolio,
+  }
+);
+
 export const memberHandlers = [
   getMyInfo,
   updateMyInfo,
@@ -187,4 +199,5 @@ export const memberHandlers = [
   updateSsafyBasicInfo,
   updateTrack,
   updatePortfolioVisibility,
+  getPortfolio,
 ];

--- a/src/mocks/handlers/member/index.ts
+++ b/src/mocks/handlers/member/index.ts
@@ -62,7 +62,7 @@ const updateMyInfo = rest.put<
   );
 });
 
-const validateNickname = restSuccess(
+export const validateNickname = restSuccess(
   'post',
   composeUrls(API_URL, endpoints.user.nickname()),
   { data: null }

--- a/src/mocks/handlers/member/index.ts
+++ b/src/mocks/handlers/member/index.ts
@@ -1,6 +1,7 @@
 import type {
   CertifyStudentApiData,
   GetMyInfoApiData,
+  MyPortfolio,
   UpdateMyInfoParams,
   UserInfo,
   UserPortfolio,
@@ -189,6 +190,15 @@ export const getPortfolio = restSuccess<UserPortfolio>(
   }
 );
 
+export const getMyPortfolio = restSuccess<MyPortfolio>(
+  'get',
+  composeUrls(API_URL, endpoints.user.myPortfolio()),
+  {
+    // data: userPortfolio.myPublicPortfolio,
+    data: userPortfolio.myPrivatePortfolio,
+  }
+);
+
 export const memberHandlers = [
   getMyInfo,
   updateMyInfo,
@@ -200,4 +210,5 @@ export const memberHandlers = [
   updateTrack,
   updatePortfolioVisibility,
   getPortfolio,
+  getMyPortfolio,
 ];

--- a/src/mocks/handlers/member/index.ts
+++ b/src/mocks/handlers/member/index.ts
@@ -161,6 +161,22 @@ export const certifyStudentAttemptsCountError = restError(
   }
 );
 
+export const updatePortfolioVisibility = restSuccess(
+  'patch',
+  composeUrls(API_URL, endpoints.user.portfolioVisibility()),
+  {
+    data: null,
+  }
+);
+
+export const updatePortfolioVisibilityError = restError(
+  'patch',
+  composeUrls(API_URL, endpoints.user.portfolioVisibility()),
+  {
+    message: '에러가 발생했습니다',
+  }
+);
+
 export const memberHandlers = [
   getMyInfo,
   updateMyInfo,
@@ -170,4 +186,5 @@ export const memberHandlers = [
   updateIsMajor,
   updateSsafyBasicInfo,
   updateTrack,
+  updatePortfolioVisibility,
 ];

--- a/src/mocks/utils.ts
+++ b/src/mocks/utils.ts
@@ -54,7 +54,7 @@ export const mockError = (
 export const restSuccess = <D extends DefaultBodyType>(
   method: 'get' | 'post' | 'patch' | 'delete',
   url: string,
-  { delay = 500, data = {} }: { delay?: number; data?: D } = {}
+  { delay = 500, data }: { delay?: number; data?: D } = {}
 ) => {
   return rest[method](url, (req, res, ctx) => {
     return res(ctx.delay(delay), ctx.json({ data }));

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -4,6 +4,7 @@ import { QueryClientProvider, Hydrate } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { useState } from 'react';
 import { Toaster } from 'react-hot-toast';
+import 'react-loading-skeleton/dist/skeleton.css';
 
 import AuthChecker from '~/components/AuthChecker';
 import Background from '~/components/Background';

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -32,7 +32,7 @@ export default function App({ Component, pageProps }: CustomAppProps) {
         <GlobalStyles />
         <Background />
         <Toaster />
-        <MainLayout withNavigation={Component.navigation}>
+        <MainLayout>
           {Component.auth ? (
             <AuthChecker auth={Component.auth}>
               <Component {...pageProps} />

--- a/src/pages/profile/[id]/index.tsx
+++ b/src/pages/profile/[id]/index.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/router';
 import { css } from '@emotion/react';
 
 import { Button, Icon, SsafyIcon, Tabs, TrackSize } from '~/components/Common';
+import NavigationGroup from '~/components/NavigationGroup';
 import { Profile } from '~/components/Profile';
 import { useMyInfo } from '~/services/member';
 import {
@@ -31,6 +32,7 @@ const ProfilePage: CustomNextPage = () => {
 
   return (
     <div css={selfCss}>
+      <NavigationGroup />
       <div css={myInfoCss}>
         NameCard
         {/* <NameCard />  */}
@@ -123,7 +125,6 @@ const ProfilePage: CustomNextPage = () => {
 };
 
 export default ProfilePage;
-ProfilePage.navigation = true;
 
 const selfPaddingX = 15;
 

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -4,16 +4,18 @@ import { useEffect } from 'react';
 
 import { DefaultFullPageLoader } from '~/components/Common';
 import { useMyInfo } from '~/services/member';
-import { routes } from '~/utils';
-
-const loaderText = '유저 정보를 확인하는 중입니다.';
+import { customToast, routes } from '~/utils';
 
 const ProfileRootPage = () => {
   const router = useRouter();
   const { data: myInfo } = useMyInfo();
 
+
   useEffect(() => {
     if (!myInfo) {
+      customToast.clientError(
+        '유저 정보를 찾을 수 없습니다. 로그인 여부를 확인해주세요.'
+      );
       router.replace(routes.main());
       return;
     }
@@ -21,12 +23,7 @@ const ProfileRootPage = () => {
     router.replace(routes.profile.detail(myInfo.memberId));
   }, [myInfo, router]);
 
-  return <DefaultFullPageLoader text={loaderText} />;
+  return <DefaultFullPageLoader text="유저 정보를 확인하는 중입니다." />;
 };
 
 export default ProfileRootPage;
-ProfileRootPage.auth = {
-  role: 'user',
-  loading: <DefaultFullPageLoader text={loaderText} />,
-  unauthorized: routes.unauthorized(),
-};

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -1,0 +1,32 @@
+import { useRouter } from 'next/router';
+
+import { useEffect } from 'react';
+
+import { DefaultFullPageLoader } from '~/components/Common';
+import { useMyInfo } from '~/services/member';
+import { routes } from '~/utils';
+
+const loaderText = '유저 정보를 확인하는 중입니다.';
+
+const ProfileRootPage = () => {
+  const router = useRouter();
+  const { data: myInfo } = useMyInfo();
+
+  useEffect(() => {
+    if (!myInfo) {
+      router.replace(routes.main());
+      return;
+    }
+
+    router.replace(routes.profile.detail(myInfo.memberId));
+  }, [myInfo, router]);
+
+  return <DefaultFullPageLoader text={loaderText} />;
+};
+
+export default ProfileRootPage;
+ProfileRootPage.auth = {
+  role: 'user',
+  loading: <DefaultFullPageLoader text={loaderText} />,
+  unauthorized: routes.unauthorized(),
+};

--- a/src/pages/profile/myinfo-settings/index.tsx
+++ b/src/pages/profile/myinfo-settings/index.tsx
@@ -13,8 +13,8 @@ import { useSignOut } from '~/services/auth';
 import {
   CertificationState,
   useMyInfo,
-  useMyPortfolio,
-  useUpdatePortfolioVisibility,
+  useProfileVisibility,
+  useUpdateProfileVisibility,
 } from '~/services/member';
 import {
   flex,
@@ -135,11 +135,11 @@ const MyInfoSettingsPage: CustomNextPage = () => {
 
 const ProfileVisibilityToggleLayer = () => {
   const { openModal, closeModal } = useModal();
-  const { data: myPortfolio, isLoading } = useMyPortfolio();
+  const { data: profileVisibility } = useProfileVisibility();
   const {
     mutate: updatePortfolioVisibility,
     isLoading: isUpdatingPortfolioVisibility,
-  } = useUpdatePortfolioVisibility();
+  } = useUpdateProfileVisibility();
 
   const openPrivateProfileAlertModal = () => {
     openModal('alert', {
@@ -165,11 +165,11 @@ const ProfileVisibilityToggleLayer = () => {
     );
   };
 
-  return isLoading ? (
+  return !profileVisibility ? (
     <ProfileVisibilityToggle.Skeleton />
   ) : (
     <ProfileVisibilityToggle
-      isPublic={myPortfolio?.isPublic}
+      isPublic={profileVisibility.isPublic}
       disabled={isUpdatingPortfolioVisibility}
       onPressedChange={handleToggleProfileVisibility}
     />

--- a/src/pages/profile/myinfo-settings/index.tsx
+++ b/src/pages/profile/myinfo-settings/index.tsx
@@ -59,7 +59,11 @@ const MyInfoSettingsPage: CustomNextPage = () => {
   return (
     <div css={selfCss}>
       <div>
-        <TitleBar.Default title="프로필 설정" withoutClose />
+        <TitleBar.Default
+          title="프로필 설정"
+          withoutClose
+          backwardAs={routes.profile.self()}
+        />
 
         <nav css={[expandCss, { marginBottom: 40 }]}>
           <MyInfoSettings.NavTitle css={navTitleCss}>

--- a/src/pages/profile/myinfo-settings/index.tsx
+++ b/src/pages/profile/myinfo-settings/index.tsx
@@ -3,17 +3,21 @@ import type { CustomNextPage } from 'next/types';
 import { useRouter } from 'next/router';
 
 import { css } from '@emotion/react';
-import { useState } from 'react';
 
-import { DefaultFullPageLoader, Toggle } from '~/components/Common';
+import { DefaultFullPageLoader } from '~/components/Common';
 import { useModal } from '~/components/GlobalModal';
 import MyInfoSettings from '~/components/MyInfoSettings';
 import TitleBar from '~/components/TitleBar';
+import { ProfileVisibilityToggle } from '~/components/Toggles';
 import { useSignOut } from '~/services/auth';
-import { CertificationState, useMyInfo } from '~/services/member';
+import {
+  CertificationState,
+  useMyInfo,
+  useMyPortfolio,
+  useUpdatePortfolioVisibility,
+} from '~/services/member';
 import {
   flex,
-  fontCss,
   globalVars,
   pageMinHeight,
   palettes,
@@ -23,12 +27,14 @@ import { EditableMyInfoFields, handleAxiosError, routes } from '~/utils';
 
 const MyInfoSettingsPage: CustomNextPage = () => {
   const { data: myInfo } = useMyInfo();
+
   const isSsafyMember = !!myInfo?.ssafyMember;
   const isCertified =
     myInfo?.ssafyInfo?.certificationState === CertificationState.CERTIFIED;
   const router = useRouter();
   const { openModal, closeModal } = useModal();
   const { mutate: signOut, isLoading: isSigningOut } = useSignOut();
+
   const handleSignOut = () => {
     signOut(undefined, {
       onSuccess: () => {
@@ -84,7 +90,7 @@ const MyInfoSettingsPage: CustomNextPage = () => {
             asLink={false}
           >
             <span>내 프로필 공개</span>
-            <ProfileVisibilityToggle />
+            <ProfileVisibilityToggleLayer />
           </MyInfoSettings.NavItem>
         </nav>
 
@@ -127,31 +133,45 @@ const MyInfoSettingsPage: CustomNextPage = () => {
   );
 };
 
-const ProfileVisibilityToggle = () => {
+const ProfileVisibilityToggleLayer = () => {
   const { openModal, closeModal } = useModal();
-  const [isPublic, setIsPublic] = useState(false);
-  const toggleText = isPublic ? '공개' : '비공개';
-  const handlePressedChange = () => {
-    if (isPublic) {
-      openModal('alert', {
-        title: '알림',
-        description: '포트폴리오 및 프로젝트, 스터디 정보가 비공개됩니다.',
-        actionText: '확인',
-        onClickAction: closeModal,
-      });
-    }
-    setIsPublic((p) => !p);
+  const { data: myPortfolio, isLoading } = useMyPortfolio();
+  const {
+    mutate: updatePortfolioVisibility,
+    isLoading: isUpdatingPortfolioVisibility,
+  } = useUpdatePortfolioVisibility();
+
+  const openPrivateProfileAlertModal = () => {
+    openModal('alert', {
+      title: '알림',
+      description: '포트폴리오 및 프로젝트, 스터디 정보가 비공개됩니다.',
+      actionText: '확인',
+      onClickAction: closeModal,
+    });
   };
 
-  return (
-    <Toggle
-      pressed={isPublic}
-      onPressedChange={handlePressedChange}
-      padding="3px 5px"
-      thumbSize={20}
-      textWidth={40}
-      text={toggleText}
-      css={fontCss.style.B12}
+  const handleToggleProfileVisibility = (isPublic: boolean) => {
+    if (!isPublic) {
+      openPrivateProfileAlertModal();
+    }
+
+    updatePortfolioVisibility(
+      { isPublic },
+      {
+        onError: (err) => {
+          handleAxiosError(err);
+        },
+      }
+    );
+  };
+
+  return isLoading ? (
+    <ProfileVisibilityToggle.Skeleton />
+  ) : (
+    <ProfileVisibilityToggle
+      isPublic={myPortfolio?.isPublic}
+      disabled={isUpdatingPortfolioVisibility}
+      onPressedChange={handleToggleProfileVisibility}
     />
   );
 };

--- a/src/pages/profile/myinfo-settings/index.tsx
+++ b/src/pages/profile/myinfo-settings/index.tsx
@@ -84,7 +84,7 @@ const MyInfoSettingsPage: CustomNextPage = () => {
 
           {isSsafyMember && !isCertified && (
             <MyInfoSettings.NavItem href={routes.certification.student()}>
-              학생 인증
+              SSAFY 인증
             </MyInfoSettings.NavItem>
           )}
 

--- a/src/pages/profile/myinfo-settings/is-major/edit.tsx
+++ b/src/pages/profile/myinfo-settings/is-major/edit.tsx
@@ -50,6 +50,9 @@ const MyInfoSettingsIsMajorEditPage = () => {
           isMajor: myInfo.isMajor,
         }}
         onValidSubmit={onValidSubmit}
+        options={{
+          titleBarBackwardRoute: routes.profile.myInfoSettings()
+        }}
       />
     </div>
   );

--- a/src/pages/profile/myinfo-settings/is-major/edit.tsx
+++ b/src/pages/profile/myinfo-settings/is-major/edit.tsx
@@ -9,7 +9,7 @@ import { DefaultFullPageLoader } from '~/components/Common';
 import MyInfoEditForm from '~/components/Forms/MyInfoEditForm';
 import { useMyInfo, useSetMyInfo, useUpdateIsMajor } from '~/services/member';
 import { flex, titleBarHeight } from '~/styles/utils';
-import { handleAxiosError, routes } from '~/utils';
+import { customToast, handleAxiosError, routes } from '~/utils';
 
 const MyInfoSettingsIsMajorEditPage = () => {
   const router = useRouter();
@@ -30,12 +30,16 @@ const MyInfoSettingsIsMajorEditPage = () => {
     );
   };
 
-  const onValidSubmit: MyInfoEditFormProps['onValidSubmit'] = async (value) => {
+  const onValidSubmit: MyInfoEditFormProps['onValidSubmit'] = async (
+    reset,
+    value
+  ) => {
     const newIsMajor = value.isMajor;
     try {
       await updateIsMajor({ isMajor: newIsMajor });
       setIsMajor(newIsMajor);
-      await router.push(routes.profile.myInfoSettings());
+      reset({ isMajor: newIsMajor });
+      customToast.success('전공자 여부가 변경되었습니다.');
     } catch (err) {
       handleAxiosError(err);
     }
@@ -51,7 +55,7 @@ const MyInfoSettingsIsMajorEditPage = () => {
         }}
         onValidSubmit={onValidSubmit}
         options={{
-          titleBarBackwardRoute: routes.profile.myInfoSettings()
+          titleBarBackwardRoute: routes.profile.myInfoSettings(),
         }}
       />
     </div>

--- a/src/pages/profile/myinfo-settings/nickname/edit.tsx
+++ b/src/pages/profile/myinfo-settings/nickname/edit.tsx
@@ -54,6 +54,9 @@ const MyInfoSettingsNicknameEditPage: CustomNextPage = () => {
           nickname: myInfo.nickname,
         }}
         onValidSubmit={onValidSubmit}
+        options={{
+          titleBarBackwardRoute: routes.profile.myInfoSettings(),
+        }}
       />
     </div>
   );

--- a/src/pages/profile/myinfo-settings/nickname/edit.tsx
+++ b/src/pages/profile/myinfo-settings/nickname/edit.tsx
@@ -10,7 +10,7 @@ import { DefaultFullPageLoader } from '~/components/Common';
 import MyInfoEditForm from '~/components/Forms/MyInfoEditForm';
 import { useMyInfo, useSetMyInfo, useUpdateNickname } from '~/services/member';
 import { flex, titleBarHeight } from '~/styles/utils';
-import { handleAxiosError, routes } from '~/utils';
+import { customToast, handleAxiosError, routes } from '~/utils';
 
 const MyInfoSettingsNicknameEditPage: CustomNextPage = () => {
   const router = useRouter();
@@ -31,7 +31,10 @@ const MyInfoSettingsNicknameEditPage: CustomNextPage = () => {
     );
   };
 
-  const onValidSubmit: MyInfoEditFormProps['onValidSubmit'] = async (value) => {
+  const onValidSubmit: MyInfoEditFormProps['onValidSubmit'] = async (
+    reset,
+    value
+  ) => {
     const newNickname = value.nickname;
     try {
       await updateNickname({
@@ -39,7 +42,8 @@ const MyInfoSettingsNicknameEditPage: CustomNextPage = () => {
       });
 
       setNickname(newNickname);
-      await router.push(routes.profile.myInfoSettings());
+      reset({ nickname: newNickname });
+      customToast.success('닉네임이 변경되었습니다.');
     } catch (err) {
       handleAxiosError(err);
     }

--- a/src/pages/profile/myinfo-settings/ssafy-basic-info/edit.tsx
+++ b/src/pages/profile/myinfo-settings/ssafy-basic-info/edit.tsx
@@ -89,6 +89,7 @@ const MyInfoSettingsSsafyBasicInfoEditPage: CustomNextPage = () => {
         onInvalidSubmit={onInvalidSubmit}
         options={{
           forceSsafyMemberToTrue: isCertified,
+          titleBarBackwardRoute: routes.profile.myInfoSettings(),
         }}
       />
     </div>

--- a/src/pages/profile/myinfo-settings/ssafy-basic-info/edit.tsx
+++ b/src/pages/profile/myinfo-settings/ssafy-basic-info/edit.tsx
@@ -31,15 +31,18 @@ const MyInfoSettingsSsafyBasicInfoEditPage: CustomNextPage = () => {
     return <DefaultFullPageLoader />;
   }
 
-  const onValidSubmit: MyInfoEditFormProps['onValidSubmit'] = async (value) => {
-    const { year: semester, ...restSsafyBasicInfo } = value.ssafyBasicInfo;
-    const newSsafyBasicInfo = {
-      semester,
-      ...restSsafyBasicInfo,
-    };
+  const onValidSubmit: MyInfoEditFormProps['onValidSubmit'] = async (
+    reset,
+    value
+  ) => {
+    const newSsafyBasicInfo = value.ssafyBasicInfo;
+    const { year: _, ...restNewSsafyBasicInfo } = value.ssafyBasicInfo;
 
     try {
-      await updateSsafyBasicInfo(newSsafyBasicInfo);
+      await updateSsafyBasicInfo({
+        ...restNewSsafyBasicInfo,
+        semester: newSsafyBasicInfo.year,
+      });
 
       setMyInfo(
         produce(myInfo, (draft) => {
@@ -53,14 +56,18 @@ const MyInfoSettingsSsafyBasicInfoEditPage: CustomNextPage = () => {
               majorTrack: null,
               ...draft.ssafyInfo,
               campus: newSsafyBasicInfo.campus,
-              semester: newSsafyBasicInfo.semester,
+              semester: newSsafyBasicInfo.year,
             };
           } else {
             delete draft.ssafyInfo;
           }
         })
       );
-      await router.push(routes.profile.myInfoSettings());
+
+      reset({
+        ssafyBasicInfo: newSsafyBasicInfo,
+      });
+      customToast.success('SSAFY 기본정보가 변경되었습니다.');
     } catch (err) {
       handleAxiosError(err);
     }

--- a/src/pages/profile/myinfo-settings/track/edit.tsx
+++ b/src/pages/profile/myinfo-settings/track/edit.tsx
@@ -59,6 +59,9 @@ const MyInfoSettingsTrackEditPage: CustomNextPage = () => {
           track: myInfo.ssafyInfo.majorTrack,
         }}
         onValidSubmit={onValidSubmit}
+        options={{
+          titleBarBackwardRoute: routes.profile.myInfoSettings(),
+        }}
       />
     </div>
   );

--- a/src/pages/profile/myinfo-settings/track/edit.tsx
+++ b/src/pages/profile/myinfo-settings/track/edit.tsx
@@ -16,7 +16,7 @@ import {
   useUpdateTrack,
 } from '~/services/member';
 import { flex, titleBarHeight } from '~/styles/utils';
-import { handleAxiosError, routes } from '~/utils';
+import { customToast, handleAxiosError, routes } from '~/utils';
 
 const MyInfoSettingsTrackEditPage: CustomNextPage = () => {
   const router = useRouter();
@@ -33,7 +33,10 @@ const MyInfoSettingsTrackEditPage: CustomNextPage = () => {
     return <DefaultFullPageLoader />;
   }
 
-  const onValidSubmit: MyInfoEditFormProps['onValidSubmit'] = async (value) => {
+  const onValidSubmit: MyInfoEditFormProps['onValidSubmit'] = async (
+    reset,
+    value
+  ) => {
     const newTrack = value.track;
     try {
       await updateTrack({ track: newTrack });
@@ -44,7 +47,8 @@ const MyInfoSettingsTrackEditPage: CustomNextPage = () => {
         })
       );
 
-      await router.push(routes.profile.myInfoSettings());
+      reset({ track: newTrack });
+      customToast.success('트랙이 변경되었습니다.');
     } catch (err) {
       handleAxiosError(err);
     }

--- a/src/pages/profile/myinfo-settings/track/edit.tsx
+++ b/src/pages/profile/myinfo-settings/track/edit.tsx
@@ -24,11 +24,12 @@ const MyInfoSettingsTrackEditPage: CustomNextPage = () => {
   const setMyInfo = useSetMyInfo();
   const { mutateAsync: updateTrack } = useUpdateTrack();
 
-  if (
+  const isUncertified =
     !myInfo ||
     !myInfo.ssafyInfo ||
-    myInfo.ssafyInfo.certificationState !== CertificationState.CERTIFIED
-  ) {
+    myInfo.ssafyInfo.certificationState !== CertificationState.CERTIFIED;
+
+  if (isUncertified) {
     router.replace(routes.unauthorized());
     return <DefaultFullPageLoader />;
   }
@@ -60,7 +61,7 @@ const MyInfoSettingsTrackEditPage: CustomNextPage = () => {
         css={formCss}
         field="track"
         defaultValues={{
-          track: myInfo.ssafyInfo.majorTrack,
+          track: myInfo.ssafyInfo.majorTrack as string,
         }}
         onValidSubmit={onValidSubmit}
         options={{

--- a/src/react-query/common/queryKeys.ts
+++ b/src/react-query/common/queryKeys.ts
@@ -2,7 +2,8 @@ export const queryKeys = {
   auth: () => ['auth'],
   user: {
     myInfo: () => [...queryKeys.auth(), 'myInfo'],
-    portfolio: (id: number) => [...queryKeys.auth(), 'portfolio', id],
+    myPortfolio: () => [...queryKeys.auth(), 'portfolio'],
+    portfolio: (id: number) => ['portfolio', id],
   },
   meta: {
     self: () => ['meta'],
@@ -20,6 +21,8 @@ export const endpoints = {
   user: {
     myInfo: () => '/members' as const,
     studentCertification: () => '/members/ssafy-certification' as const,
+
+    myPortfolio: () => `/members/portfolio`,
     portfolio: (id: number) => `/members/${id}/portfolio` as const,
 
     ssafyBasicInfo: () => '/members/default-information' as const,

--- a/src/react-query/common/queryKeys.ts
+++ b/src/react-query/common/queryKeys.ts
@@ -2,6 +2,7 @@ export const queryKeys = {
   auth: () => ['auth'],
   user: {
     myInfo: () => [...queryKeys.auth(), 'myInfo'],
+    portfolio: (id: number) => [...queryKeys.auth(), 'portfolio', id],
   },
   meta: {
     self: () => ['meta'],
@@ -19,11 +20,13 @@ export const endpoints = {
   user: {
     myInfo: () => '/members' as const,
     studentCertification: () => '/members/ssafy-certification' as const,
+    portfolio: (id: number) => `/members/${id}/portfolio` as const,
 
     ssafyBasicInfo: () => '/members/default-information' as const,
     nickname: () => '/members/nickname' as const,
     isMajor: () => '/members/major' as const,
     track: () => '/members/major-track' as const,
+    portfolioVisibility: () => '/members/portfolio-public' as const,
   },
   recruit: {
     // todo 이름, 파라미터 수정

--- a/src/react-query/common/queryKeys.ts
+++ b/src/react-query/common/queryKeys.ts
@@ -4,6 +4,7 @@ export const queryKeys = {
     myInfo: () => [...queryKeys.auth(), 'myInfo'],
     myPortfolio: () => [...queryKeys.auth(), 'portfolio'],
     portfolio: (id: number) => ['portfolio', id],
+    profileVisibility: () => ['profileVisibility'],
   },
   meta: {
     self: () => ['meta'],
@@ -29,7 +30,7 @@ export const endpoints = {
     nickname: () => '/members/nickname' as const,
     isMajor: () => '/members/major' as const,
     track: () => '/members/major-track' as const,
-    portfolioVisibility: () => '/members/portfolio-public' as const,
+    profileVisibility: () => '/members/profile-public' as const,
   },
   recruit: {
     // todo 이름, 파라미터 수정

--- a/src/services/member/apis.ts
+++ b/src/services/member/apis.ts
@@ -99,3 +99,14 @@ export const certifyStudent = (params: CertifyStudentParams) => {
     .post<CertifyStudentApiData>(endpoint, params)
     .then((res) => res.data.data);
 };
+
+interface UpdatePortfolioVisibilityParams {
+  public: boolean;
+}
+
+export const updatePortfolioVisibility = (
+  params: UpdatePortfolioVisibilityParams
+) => {
+  const endpoint = endpoints.user.portfolioVisibility();
+  return privateAxios.post(endpoint, params).then((res) => res.data);
+};

--- a/src/services/member/apis.ts
+++ b/src/services/member/apis.ts
@@ -1,4 +1,9 @@
-import type { UserInfo, SsafyTrack, UserPortfolio } from './utils/types';
+import type {
+  UserInfo,
+  SsafyTrack,
+  UserPortfolio,
+  MyPortfolio,
+} from './utils/types';
 import type { ApiSuccessResponse } from '~/types';
 
 import { endpoints } from '~/react-query/common';
@@ -101,24 +106,32 @@ export const certifyStudent = (params: CertifyStudentParams) => {
 };
 
 interface UpdatePortfolioVisibilityParams {
-  public: boolean;
+  isPublic: boolean;
 }
 
 export const updatePortfolioVisibility = (
   params: UpdatePortfolioVisibilityParams
 ) => {
   const endpoint = endpoints.user.portfolioVisibility();
-  return privateAxios.post(endpoint, params).then((res) => res.data);
+  return privateAxios.patch(endpoint, params).then((res) => res.data);
 };
 
 // 포트폴리오
 
-type GetPortfolioApiData = ApiSuccessResponse<UserPortfolio>;
-
-export const getPortfolio = (id: number) => {
+type GetUserPortfolioApiData = ApiSuccessResponse<UserPortfolio>;
+export const getUserPortfolio = (id: number) => {
   const endpoint = endpoints.user.portfolio(id);
 
   return privateAxios
-    .get<GetPortfolioApiData>(endpoint)
+    .get<GetUserPortfolioApiData>(endpoint)
+    .then((res) => res.data.data);
+};
+
+type GetMyPortfolioApiData = ApiSuccessResponse<MyPortfolio>;
+export const getMyPortfolio = () => {
+  const endpoint = endpoints.user.myPortfolio();
+
+  return privateAxios
+    .get<GetMyPortfolioApiData>(endpoint)
     .then((res) => res.data.data);
 };

--- a/src/services/member/apis.ts
+++ b/src/services/member/apis.ts
@@ -1,4 +1,4 @@
-import type { UserInfo, SsafyTrack } from './utils/types';
+import type { UserInfo, SsafyTrack, UserPortfolio } from './utils/types';
 import type { ApiSuccessResponse } from '~/types';
 
 import { endpoints } from '~/react-query/common';
@@ -109,4 +109,16 @@ export const updatePortfolioVisibility = (
 ) => {
   const endpoint = endpoints.user.portfolioVisibility();
   return privateAxios.post(endpoint, params).then((res) => res.data);
+};
+
+// 포트폴리오
+
+type GetPortfolioApiData = ApiSuccessResponse<UserPortfolio>;
+
+export const getPortfolio = (id: number) => {
+  const endpoint = endpoints.user.portfolio(id);
+
+  return privateAxios
+    .get<GetPortfolioApiData>(endpoint)
+    .then((res) => res.data.data);
 };

--- a/src/services/member/apis.ts
+++ b/src/services/member/apis.ts
@@ -3,6 +3,7 @@ import type {
   SsafyTrack,
   UserPortfolio,
   MyPortfolio,
+  ProfileVisibility,
 } from './utils/types';
 import type { ApiSuccessResponse } from '~/types';
 
@@ -105,14 +106,24 @@ export const certifyStudent = (params: CertifyStudentParams) => {
     .then((res) => res.data.data);
 };
 
-interface UpdatePortfolioVisibilityParams {
+export type GetProfileVisibilityApiData = ApiSuccessResponse<ProfileVisibility>;
+
+export const getProfileVisibility = () => {
+  const endpoint = endpoints.user.profileVisibility();
+
+  return privateAxios
+    .get<GetProfileVisibilityApiData>(endpoint)
+    .then((res) => res.data.data);
+};
+
+interface UpdateProfileVisibilityParams {
   isPublic: boolean;
 }
 
-export const updatePortfolioVisibility = (
-  params: UpdatePortfolioVisibilityParams
+export const updateProfileVisibility = (
+  params: UpdateProfileVisibilityParams
 ) => {
-  const endpoint = endpoints.user.portfolioVisibility();
+  const endpoint = endpoints.user.profileVisibility();
   return privateAxios.patch(endpoint, params).then((res) => res.data);
 };
 

--- a/src/services/member/hooks.ts
+++ b/src/services/member/hooks.ts
@@ -1,4 +1,4 @@
-import type { MyPortfolio, UserInfo } from '~/services/member/utils';
+import type { ProfileVisibility, UserInfo } from '~/services/member/utils';
 
 import { useRouter } from 'next/router';
 
@@ -12,11 +12,12 @@ import {
   certifyStudent,
   getMyInfo,
   getMyPortfolio,
+  getProfileVisibility,
   getUserPortfolio,
   updateIsMajor,
   updateMyInfo,
   updateNickname,
-  updatePortfolioVisibility,
+  updateProfileVisibility,
   updateSsafyBasicInfo,
   updateTrack,
   validateNickname,
@@ -135,35 +136,41 @@ export const useCertifyStudent = () => {
   });
 };
 
-export const useUpdatePortfolioVisibility = () => {
+// 프로필
+
+export const useProfileVisibility = () => {
+  return useQuery({
+    queryKey: queryKeys.user.profileVisibility(),
+    queryFn: getProfileVisibility,
+  });
+};
+
+export const useUpdateProfileVisibility = () => {
   const queryClient = useQueryClient();
-  const setMyPortfolio = useSetMyPortfolio();
+  const profileVisibilityQueryKey = queryKeys.user.profileVisibility();
+  const setProfileVisibility = (updater?: ProfileVisibility) =>
+    queryClient.setQueryData<ProfileVisibility>(
+      profileVisibilityQueryKey,
+      updater
+    );
 
   return useMutation({
-    mutationFn: updatePortfolioVisibility,
+    mutationFn: updateProfileVisibility,
     onMutate: async ({ isPublic }) => {
-      const myPortfolioQueryKey = queryKeys.user.myPortfolio();
-      await queryClient.cancelQueries(myPortfolioQueryKey);
-      const prevMyPortfolio =
-        queryClient.getQueryData<MyPortfolio>(myPortfolioQueryKey);
-
-      if (prevMyPortfolio) {
-        setMyPortfolio({
-          ...prevMyPortfolio,
-          isPublic,
-        });
-      }
-
-      return { prevMyPortfolio };
+      await queryClient.cancelQueries(profileVisibilityQueryKey);
+      const prevProfileVisibility = queryClient.getQueryData<ProfileVisibility>(
+        profileVisibilityQueryKey
+      );
+      setProfileVisibility({ isPublic });
+      return { prevProfileVisibility };
     },
-    onError: (err, _, context) => {
-      console.error(err);
-      setMyPortfolio(context?.prevMyPortfolio);
+    onError: (err, variables, context) => {
+      setProfileVisibility(context?.prevProfileVisibility);
     },
   });
 };
 
-// 포트폴리오
+// 프로필 - 포트폴리오
 
 export const useUserPortfolio = (id: number) => {
   return useQuery({
@@ -177,17 +184,4 @@ export const useMyPortfolio = () => {
     queryKey: queryKeys.user.myPortfolio(),
     queryFn: getMyPortfolio,
   });
-};
-
-export const useSetMyPortfolio = () => {
-  const queryClient = useQueryClient();
-  const queryKey = queryKeys.user.myPortfolio();
-
-  const setMyPortfolio = (
-    updater?: MyPortfolio | ((payload?: MyPortfolio) => MyPortfolio | undefined)
-  ) => {
-    queryClient.setQueryData<MyPortfolio>(queryKey, updater);
-  };
-
-  return setMyPortfolio;
 };

--- a/src/services/member/hooks.ts
+++ b/src/services/member/hooks.ts
@@ -11,6 +11,7 @@ import { routes } from '~/utils/routes';
 import {
   certifyStudent,
   getMyInfo,
+  getPortfolio,
   updateIsMajor,
   updateMyInfo,
   updateNickname,
@@ -136,5 +137,14 @@ export const useCertifyStudent = () => {
 export const useUpdatePortfolioVisibility = () => {
   return useMutation({
     mutationFn: updatePortfolioVisibility,
+  });
+};
+
+// 포트폴리오
+
+export const usePortfolio = (id: number) => {
+  return useQuery({
+    queryKey: queryKeys.user.portfolio(id),
+    queryFn: () => getPortfolio(id),
   });
 };

--- a/src/services/member/hooks.ts
+++ b/src/services/member/hooks.ts
@@ -14,6 +14,7 @@ import {
   updateIsMajor,
   updateMyInfo,
   updateNickname,
+  updatePortfolioVisibility,
   updateSsafyBasicInfo,
   updateTrack,
   validateNickname,
@@ -129,5 +130,11 @@ export const useValidateNickname = () => {
 export const useCertifyStudent = () => {
   return useMutation({
     mutationFn: certifyStudent,
+  });
+};
+
+export const useUpdatePortfolioVisibility = () => {
+  return useMutation({
+    mutationFn: updatePortfolioVisibility,
   });
 };

--- a/src/services/member/utils/types.ts
+++ b/src/services/member/utils/types.ts
@@ -56,7 +56,13 @@ export type UserSsafyInfo =
 
 export type UserInfo = UserBasicInfo & UserSsafyInfo;
 
-// 포트폴리오
+// 프로필
+
+export interface ProfileVisibility {
+  isPublic: boolean;
+}
+
+// 프로필 - 포트폴리오
 
 export interface PortfolioExternalLink {
   linkName: string;

--- a/src/services/member/utils/types.ts
+++ b/src/services/member/utils/types.ts
@@ -55,3 +55,26 @@ export type UserSsafyInfo =
     };
 
 export type UserInfo = UserBasicInfo & UserSsafyInfo;
+
+// 포트폴리오
+
+export interface PortfolioExternalLink {
+  linkName: string;
+  path: string;
+}
+
+export interface Portfolio {
+  selfIntroduction: string;
+  skills: string[];
+  memberLinks: PortfolioExternalLink[];
+}
+
+export type UserPortfolio =
+  | {
+      isPublic: false;
+      portfolio: null;
+    }
+  | {
+      isPublic: true;
+      portfolio: Portfolio;
+    };

--- a/src/services/member/utils/types.ts
+++ b/src/services/member/utils/types.ts
@@ -78,3 +78,8 @@ export type UserPortfolio =
       isPublic: true;
       portfolio: Portfolio;
     };
+
+export type MyPortfolio = {
+  isPublic: boolean;
+  portfolio: Portfolio;
+};

--- a/src/stories/IsMajorEditPage.stories.tsx
+++ b/src/stories/IsMajorEditPage.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { useEffect } from 'react';
+
+import { updateIsMajor } from '~/mocks/handlers/member';
+import { userInfo } from '~/mocks/handlers/member/data';
+import MyInfoSettingsIsMajorEditPage from '~/pages/profile/myinfo-settings/is-major/edit';
+import { useSetMyInfo } from '~/services/member';
+import { PageLayout } from '~/stories/Layout';
+
+const meta: Meta<typeof MyInfoSettingsIsMajorEditPage> = {
+  title: 'Page/MyInfoSettings/IsMajorEdit',
+  component: MyInfoSettingsIsMajorEditPage,
+  decorators: [
+    (Story) => (
+      <PageLayout>
+        <Story />
+      </PageLayout>
+    ),
+  ],
+  parameters: {
+    layout: 'fullscreen',
+
+    msw: {
+      handlers: {
+        member: [updateIsMajor],
+      },
+    },
+  },
+};
+
+export default meta;
+
+type IsMajorEditPageStory = StoryObj<typeof MyInfoSettingsIsMajorEditPage>;
+
+export const Default: IsMajorEditPageStory = {
+  decorators: [
+    (Story) => {
+      const setMyInfo = useSetMyInfo();
+      useEffect(() => {
+        setMyInfo(userInfo.certifiedSsafyUserInfo);
+      }, [setMyInfo]);
+
+      return <Story />;
+    },
+  ],
+};

--- a/src/stories/MyInfoSettingsPage.stories.tsx
+++ b/src/stories/MyInfoSettingsPage.stories.tsx
@@ -2,6 +2,10 @@ import type { Meta, StoryObj } from '@storybook/react';
 
 import { useEffect } from 'react';
 
+import {
+  getProfileVisibility,
+  updateProfileVisibility,
+} from '~/mocks/handlers/member';
 import { userInfo } from '~/mocks/handlers/member/data';
 import MyInfoSettingsPage from '~/pages/profile/myinfo-settings';
 import { useSetMyInfo } from '~/services/member';
@@ -22,7 +26,7 @@ const meta: Meta<typeof MyInfoSettingsPage> = {
 
     msw: {
       handlers: {
-        member: [],
+        member: [getProfileVisibility, updateProfileVisibility],
       },
     },
   },

--- a/src/stories/NicknameEditPage.stories.tsx
+++ b/src/stories/NicknameEditPage.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { useEffect } from 'react';
+
+import { updateNickname, validateNickname } from '~/mocks/handlers/member';
+import { userInfo } from '~/mocks/handlers/member/data';
+import MyInfoSettingsNicknameEditPage from '~/pages/profile/myinfo-settings/nickname/edit';
+import { useSetMyInfo } from '~/services/member';
+import { PageLayout } from '~/stories/Layout';
+
+const meta: Meta<typeof MyInfoSettingsNicknameEditPage> = {
+  title: 'Page/MyInfoSettings/NicknameEdit',
+  component: MyInfoSettingsNicknameEditPage,
+  decorators: [
+    (Story) => (
+      <PageLayout>
+        <Story />
+      </PageLayout>
+    ),
+  ],
+  parameters: {
+    layout: 'fullscreen',
+
+    msw: {
+      handlers: {
+        member: [updateNickname, validateNickname],
+      },
+    },
+  },
+};
+
+export default meta;
+
+type NicknameEditPageStory = StoryObj<typeof MyInfoSettingsNicknameEditPage>;
+
+export const Default: NicknameEditPageStory = {
+  decorators: [
+    (Story) => {
+      const setMyInfo = useSetMyInfo();
+      useEffect(() => {
+        setMyInfo(userInfo.certifiedSsafyUserInfo);
+      }, [setMyInfo]);
+
+      return <Story />;
+    },
+  ],
+};

--- a/src/stories/SsafyBasicInfoEditPage.stories.tsx
+++ b/src/stories/SsafyBasicInfoEditPage.stories.tsx
@@ -4,6 +4,7 @@ import { expect } from '@storybook/jest';
 import { userEvent, within } from '@storybook/testing-library';
 import { useEffect } from 'react';
 
+import { updateSsafyBasicInfo } from '~/mocks/handlers';
 import { userInfo } from '~/mocks/handlers/member/data';
 import MyInfoSettingsSsafyBasicInfoEditPage from '~/pages/profile/myinfo-settings/ssafy-basic-info/edit';
 import { useSetMyInfo } from '~/services/member';
@@ -25,7 +26,7 @@ const meta: Meta<typeof MyInfoSettingsSsafyBasicInfoEditPage> = {
 
     msw: {
       handlers: {
-        member: [],
+        member: [updateSsafyBasicInfo],
       },
     },
   },

--- a/src/stories/TrackEditPage.stories.tsx
+++ b/src/stories/TrackEditPage.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { useEffect } from 'react';
+
+import { updateTrack } from '~/mocks/handlers/member';
+import { userInfo } from '~/mocks/handlers/member/data';
+import MyInfoSettingsTrackEditPage from '~/pages/profile/myinfo-settings/track/edit';
+import { useSetMyInfo } from '~/services/member';
+import { PageLayout } from '~/stories/Layout';
+
+const meta: Meta<typeof MyInfoSettingsTrackEditPage> = {
+  title: 'Page/MyInfoSettings/TrackEdit',
+  component: MyInfoSettingsTrackEditPage,
+  decorators: [
+    (Story) => (
+      <PageLayout>
+        <Story />
+      </PageLayout>
+    ),
+  ],
+  parameters: {
+    layout: 'fullscreen',
+
+    msw: {
+      handlers: {
+        member: [updateTrack],
+      },
+    },
+  },
+};
+
+export default meta;
+
+type TrackEditPageStory = StoryObj<typeof MyInfoSettingsTrackEditPage>;
+
+export const Default: TrackEditPageStory = {
+  decorators: [
+    (Story) => {
+      const setMyInfo = useSetMyInfo();
+      useEffect(() => {
+        setMyInfo(userInfo.certifiedSsafyUserInfo);
+      }, [setMyInfo]);
+
+      return <Story />;
+    },
+  ],
+};

--- a/src/types/next.d.ts
+++ b/src/types/next.d.ts
@@ -19,13 +19,10 @@ type NextPageConfig = {
      */
     unauthorized: ReactElement | string;
   };
-
-  navigation: boolean;
 };
 
 declare module 'next/types' {
   export type NextPageAuthConfig = NextPageConfig['auth'];
-  export type NextPageNavigationConfig = NextPageConfig['navigation'];
 
   // eslint-disable-next-line
   export type CustomNextPage<Props = {}, InitialProps = Props> = NextPage<

--- a/src/utils/customToast.tsx
+++ b/src/utils/customToast.tsx
@@ -6,8 +6,13 @@ const clientErrorToast = (message: string) => {
   return toast((t) => <Toast.ServerError clientMessage={message} t={t} />);
 };
 
+const successToast = (message: string) => {
+  return toast((t) => <Toast.Success message={message} t={t} />);
+};
+
 const customToast = {
   clientError: clientErrorToast,
+  success: successToast,
 };
 
 export default customToast;

--- a/yarn.lock
+++ b/yarn.lock
@@ -16447,6 +16447,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-loading-skeleton@npm:^3.3.1":
+  version: 3.3.1
+  resolution: "react-loading-skeleton@npm:3.3.1"
+  peerDependencies:
+    react: ">=16.8.0"
+  checksum: 0de3437a5da8b7133bf86043e4e002e5422b50cd71b9a650f2947a89ace39be8b7c61a098f1d7dd0be559dc3ac293d60697fdae23cb09c3905b2952e1a68693d
+  languageName: node
+  linkType: hard
+
 "react-quill@npm:^2.0.0":
   version: 2.0.0
   resolution: "react-quill@npm:2.0.0"
@@ -17721,6 +17730,7 @@ __metadata:
     react-hook-form: ^7.45.0
     react-hot-toast: ^2.4.1
     react-icons: ^4.9.0
+    react-loading-skeleton: ^3.3.1
     react-quill: ^2.0.0
     react-spinners: ^0.13.8
     react-zoom-pan-pinch: ^3.1.0


### PR DESCRIPTION
## Issues

- #118 

<!-- 이슈 번호를 작성해주세요. 여러 이슈 번호를 작성해도 됩니다. -->

## 구분

- [ ] 버그 수정
- [x] 기능 추가
- [x] 코드 리팩터링
- [ ] 문서 업데이트
- [ ] 기타

<!-- 어떤 이유로 코드를 변경했는지 체크해주세요. -->

## 주요 변경점

- 토스트 업데이트
  - Success토스트를 추가하였고, 공통된 스타일을 위해 ToastRoot 컴포넌트 추가
  - 토스트 스토리 업데이트

- `Forms/Common/Nickname` 에 속해있던 컴포넌트들을 `UserRegisterForm/Fields/Nickname`으로 이동

- 업데이트 완료 후 내정보 페이지 (`/profile/myinfo-settings`)로 이동하던걸, 업데이트 페이지에 그대로 머무르도록 변경
  - MyInfoEditForm에 해당 form의 defaultValues를 reset하기 위한 onValidSubmit의 시그니처 업데이트 (첫번째 인자로 reset 함수를 전달)

- 페이지 컴포넌트에  `PageComponent.navigation = true`할당하는 방식으로 Gnb와 TopBar 렌더링하는 기능 삭제
   - `MainLayout`, `next.d.ts`, `_app.tsx` 업데이트
   - Gnb, TopBar컴포넌트가 필요한 페이지에 `NavigationGroup`직접 렌더링

- `ProfileVisibilityToggle`컴포넌트를 따로 `Toggles/**`로 분리

- 포트폴리오 모킹 데이터 추가


<!-- 주요 변경점과 어떤 부분을 집중해서 리뷰해야 하는지 알려주세요. -->

## 스크린샷


<!-- 관련 미디어 파일이 있으면 첨부해주세요. -->

## 기타

<!-- 추가로 전달할 내용, 메모할 내용, 테스트 계획, 완료된 테스트 등을 알려주세요. -->

