### PR TITLE
Fix `privateAxios` interceptors test

### DIFF
--- a/src/utils/axios.ts
+++ b/src/utils/axios.ts
@@ -1,4 +1,8 @@
-import type { InternalAxiosRequestConfig, AxiosError } from 'axios';
+import type {
+  InternalAxiosRequestConfig,
+  AxiosError,
+  AxiosInstance,
+} from 'axios';
 import type { ApiErrorResponse } from '~/types';
 
 import * as Sentry from '@sentry/nextjs';
@@ -46,28 +50,40 @@ const detectRequestInfiniteLoop = createRequestInfiniteLoopDetector(5, {
   },
 });
 
-const configurePublicAxiosInterceptors = () => {
+export const configurePublicAxiosInterceptors = (
+  axiosInstance: AxiosInstance
+) => {
   if (isDevMode) {
-    publicAxios.interceptors.request.use((config) => {
+    axiosInstance.interceptors.request.use((config) => {
       devPlugin(config);
       return config;
     });
   }
 };
 
-const configurePrivateAxiosInterceptors = (
+interface ConfigurePrivateAxiosInterceptorsOptions {
+  /** Token 재발급을 트리거할 ResponseCode  */
+  reissueTokenTriggerCodes: string[];
+  /** Token 재발급이 트리거되었을 때, 재발급을 생략할지 여부를 `boolean`으로 반환하는 함수 */
+  skipReissueToken?: () => boolean;
+}
+
+export const configurePrivateAxiosInterceptors = (
+  axiosInstance: AxiosInstance,
   reissueToken: () => Promise<unknown>,
-  responseCodesTriggerReissueToken: string[]
+  options: ConfigurePrivateAxiosInterceptorsOptions
 ) => {
   let reissueTokenRequest: ReturnType<typeof reissueToken> | undefined;
   const waitingQueue = new Set<InternalAxiosRequestConfig>();
+  const { reissueTokenTriggerCodes, skipReissueToken = () => false } = options;
+  const reissueTokenTriggerCodesSet = new Set<string>(reissueTokenTriggerCodes);
 
   /**
-   * - 토큰 재발급 수행 중에 privateAxios 요청이 감지된 경우, 해당 요청을 서버에 보내지 않고 대기시킵니다.
+   * - 토큰 재발급 수행 중에 axiosInstance 요청이 감지된 경우, 해당 요청을 서버에 보내지 않고 대기시킵니다.
    * - 토큰 재발급에 성공하면, 대기중인 요청을 서버에 보냅니다.
    * - 토큰 재발급에 실패하면, 대기중인 요청을 서버에 보내지 않고 즉시 실패시킵니다.
    */
-  privateAxios.interceptors.request.use((config) => {
+  axiosInstance.interceptors.request.use((config) => {
     devPlugin(config);
 
     if (reissueTokenRequest === undefined) return config;
@@ -75,12 +91,12 @@ const configurePrivateAxiosInterceptors = (
   });
 
   /**
-   * - privateAxios 요청에 대한 응답 데이터에 토큰 재발급이 필요하다는 code가 포함되었다면,
+   * - axiosInstance 요청에 대한 응답 데이터에 토큰 재발급이 필요하다는 code가 포함되었다면,
    * 토큰 재발급을 수행하고, Reject될 예정이었던 요청을 대기시킵니다.
    * - 토큰 재발급에 성공한 경우, 대기중인 요청을 다시 서버로 전송합니다.
    * - 토큰 재발급에 실패한 경우, 대기중인 요청을 실패시킵니다.
    */
-  privateAxios.interceptors.response.use(
+  axiosInstance.interceptors.response.use(
     undefined,
     (error: AxiosError<ApiErrorResponse> | Error) => {
       const tag = `[In privateAxios response interceptor]`;
@@ -90,22 +106,24 @@ const configurePrivateAxiosInterceptors = (
       }
 
       const requestConfig = error.config;
-      const retryFailedRequest = () => privateAxios.request(requestConfig);
-
+      const retryFailedRequest = () => axiosInstance.request(requestConfig);
       const statusCode = error.response.status;
+
       if (statusCode >= 500) {
         console.error(`${tag}: Server Error`);
         return Promise.reject(error);
       }
 
-      console.error(`${tag}: Client Error`);
       const response = error.response.data;
+      const errorMessage = response?.message;
 
-      if (!responseCodesTriggerReissueToken.includes(response.code)) {
+      if (!reissueTokenTriggerCodesSet.has(response.code)) {
+        console.error(`${tag}: ${errorMessage}`);
         return Promise.reject(error);
       }
 
-      if (detectRequestInfiniteLoop()) return;
+      console.error(`${tag}: Token Expired`);
+      if (skipReissueToken()) return;
 
       if (reissueTokenRequest === undefined) {
         reissueTokenRequest = reissueToken();
@@ -125,6 +143,9 @@ const configurePrivateAxiosInterceptors = (
   );
 };
 
-configurePrivateAxiosInterceptors(reissueToken, [ResponseCode.EXPIRED_TOKEN]);
+configurePrivateAxiosInterceptors(privateAxios, reissueToken, {
+  reissueTokenTriggerCodes: [ResponseCode.EXPIRED_TOKEN],
+  skipReissueToken: detectRequestInfiniteLoop,
+});
 
-configurePublicAxiosInterceptors();
+configurePublicAxiosInterceptors(publicAxios);

--- a/src/utils/tests/axios.test.ts
+++ b/src/utils/tests/axios.test.ts
@@ -1,60 +1,76 @@
+import type { AxiosInstance } from 'axios';
 import type { ApiErrorResponse } from '~/types';
 
+import axios from 'axios';
 import { rest } from 'msw';
 
 import { server } from '~/mocks/server';
 import { endpoints } from '~/react-query/common';
 import {
-  API_URL,
   composeUrls,
-  privateAxios,
+  configurePrivateAxiosInterceptors,
   ResponseCode,
   sleep,
 } from '~/utils';
 
-const privatePath = '/private';
+const baseUrl = 'https://test.com/';
+const privateRequestEndpoint = composeUrls(baseUrl, '/private');
+const refreshTokenEndpoint = composeUrls(baseUrl, endpoints.auth.refresh());
+const reissueToken = jest.fn(() => {
+  return axios.post(refreshTokenEndpoint);
+});
 
 const setupMSW = (
   serverTaskOnReissueToken: () => void,
   serverTaskOnPrivateRequest?: () => void,
   serverTaskDelayOnReissueToken = 0
 ) => {
-  const cookies = { token: undefined } as { token?: string };
+  const EXPIRED = 'EXPIRED';
+  const VALID = 'VALID';
+  const cookies = { token: EXPIRED } as { token?: string };
+
   server.use(
-    rest.get(composeUrls(API_URL, privatePath), (req, res, ctx) => {
+    rest.get(privateRequestEndpoint, (req, res, ctx) => {
       serverTaskOnPrivateRequest?.();
-      if (cookies.token) {
-        return res(ctx.status(200));
+
+      if (cookies.token === EXPIRED) {
+        return res(
+          ctx.status(400),
+          ctx.json<ApiErrorResponse>({
+            message: '',
+            code: ResponseCode.EXPIRED_TOKEN,
+          })
+        );
       }
 
-      return res(
-        ctx.status(400),
-        ctx.json<ApiErrorResponse>({
-          message: '',
-          code: ResponseCode.EXPIRED_TOKEN,
-        })
-      );
+      return res(ctx.status(200));
     }),
 
-    rest.post(
-      composeUrls(API_URL, endpoints.auth.refresh()),
-      async (req, res, ctx) => {
-        await sleep(serverTaskDelayOnReissueToken);
-        serverTaskOnReissueToken();
-        cookies.token = 'token';
-        return res(ctx.status(200));
-      }
-    )
+    rest.post(refreshTokenEndpoint, async (req, res, ctx) => {
+      await sleep(serverTaskDelayOnReissueToken);
+      serverTaskOnReissueToken();
+      cookies.token = VALID;
+      return res(ctx.status(200));
+    })
   );
 };
 
 describe('privateAxios interceptors test', () => {
-  it('`privateAxios`로 여러개의 요청을 보낼 때, 토큰 만료로 요청이 실패한 경우, 토큰 재발급 요청은 1회만 보내야 한다.', async () => {
+  let axiosInstance: AxiosInstance;
+  beforeEach(() => {
+    axiosInstance = axios.create();
+    configurePrivateAxiosInterceptors(axiosInstance, reissueToken, {
+      reissueTokenTriggerCodes: [ResponseCode.EXPIRED_TOKEN],
+      skipReissueToken: () => false,
+    });
+  });
+
+  it('`privateAxios`로 여러개의 요청을 보낼 때, 토큰 만료로 요청이 실패한 경우, 토큰 재발급 요청은 1회만 보낸다.', async () => {
     const serverTaskOnReissueToken = jest.fn();
 
     setupMSW(serverTaskOnReissueToken);
 
-    const privateRequest = () => privateAxios.get(privatePath);
+    const privateRequest = () => axiosInstance.get(privateRequestEndpoint);
 
     await Promise.allSettled([
       privateRequest(),
@@ -66,13 +82,13 @@ describe('privateAxios interceptors test', () => {
     expect(serverTaskOnReissueToken).toBeCalledTimes(1);
   });
 
-  it('`privateAxios`로 여러개의 요청을 보낼 때, 토큰 만료로 요청이 실패한 경우, 토큰 재발급 이후에 실패했던 요청들이 재전송되어야 한다.', async () => {
+  it('`privateAxios`로 여러개의 요청을 보낼 때, 토큰 만료로 요청이 실패한 경우, 토큰 재발급 이후에 실패했던 요청들이 재전송된다.', async () => {
     const serverTaskOnReissueToken = jest.fn();
     const serverTaskOnPrivateRequest = jest.fn();
 
     setupMSW(serverTaskOnReissueToken, serverTaskOnPrivateRequest);
 
-    const privateRequest = () => privateAxios.get(privatePath);
+    const privateRequest = () => axiosInstance.get(privateRequestEndpoint);
 
     await Promise.allSettled([
       privateRequest(),
@@ -95,8 +111,8 @@ describe('privateAxios interceptors test', () => {
       serverTaskDelayOnReissueToken
     );
 
-    const privateRequest = () => privateAxios.get(privatePath);
-    const latePrivateRequest = () => privateAxios.get(privatePath);
+    const privateRequest = () => axiosInstance.get(privateRequestEndpoint);
+    const latePrivateRequest = () => axiosInstance.get(privateRequestEndpoint);
 
     setTimeout(() => latePrivateRequest(), serverTaskDelayOnReissueToken / 2);
     await privateRequest();


### PR DESCRIPTION
## 구분
- [x] 버그 수정
- [ ] 기능 추가
- [ ] 코드 리팩터링
- [ ] 문서 업데이트
- [ ] 기타

<!-- 어떤 이유로 코드를 변경했는지 체크해주세요. -->

## 주요 변경점

- `detectInfiniteLoop`추가에 따른 test 실패로 인해 `detectInfiniteLoop`를 `configurePrivateAxiosInterceptors`함수의 파라미터로 받을 수 있도록 변경 

<!-- 주요 변경점과 어떤 부분을 집중해서 리뷰해야 하는지 알려주세요. -->

## 스크린샷


<!-- 관련 미디어 파일이 있으면 첨부해주세요. -->

## 기타

<!-- 추가로 전달할 내용, 메모할 내용, 테스트 계획, 완료된 테스트 등을 알려주세요. -->

