### PR TITLE
Fix: 메인 페이지 점심메뉴 미리보기 레이아웃, 이스케이프 처리된 문자열 렌더링

### DIFF
--- a/src/components/ArticleCard/ArticleCard.tsx
+++ b/src/components/ArticleCard/ArticleCard.tsx
@@ -31,8 +31,10 @@ export const ArticleCard = memo((props: ArticleCardProps) => {
   return (
     <ArticleCardLink href={routes.article.detail(articleId)}>
       <h2 css={[titleCss, { marginBottom: 2 }]}>{title}</h2>
-
-      <p css={[contentCss, { marginBottom: 24 }]}>{strippedHtml}</p>
+      <p
+        css={[contentCss, { marginBottom: 24 }]}
+        dangerouslySetInnerHTML={{ __html: strippedHtml }}
+      />
 
       <div css={footerCss}>
         <div css={metaCss}>
@@ -65,7 +67,7 @@ const clampCss = css(
 
 const titleCss = css(fontCss.style.B18, clampCss);
 
-const contentCss = css(fontCss.style.R14, clampCss);
+const contentCss = css(fontCss.style.R14, fontCss.family.pretendard, clampCss);
 
 const footerCss = css(flex('center', 'space-between', 'row'));
 

--- a/src/components/ArticleCard/HotArticleCard.tsx
+++ b/src/components/ArticleCard/HotArticleCard.tsx
@@ -43,7 +43,10 @@ export const HotArticleCard = memo((props: HotArticleCardProps) => {
 
       <h2 css={[articleTitleCss, { marginBottom: 4 }]}>{articleTitle}</h2>
 
-      <p css={[contentCss, { marginBottom: 10 }]}>{strippedHtml}</p>
+      <p
+        css={[contentCss, { marginBottom: 10 }]}
+        dangerouslySetInnerHTML={{ __html: strippedHtml }}
+      />
 
       <div css={metaCss}>
         <span>{timeAgo(createdAt)}</span>
@@ -67,7 +70,7 @@ const articleTitleCss = css(fontCss.style.B14, clampCss);
 
 const categoryCss = css({ color: palettes.point.purple }, fontCss.style.B18);
 
-const contentCss = css(fontCss.style.R14, clampCss);
+const contentCss = css(fontCss.style.R14, fontCss.family.pretendard, clampCss);
 
 const headerCss = css(flex('center', 'space-between', 'row', 16));
 

--- a/src/components/Editor/Editor.tsx
+++ b/src/components/Editor/Editor.tsx
@@ -71,7 +71,7 @@ const selfCss = css({
     borderBottom: 0,
   },
   [`& .${cn.editor}`]: {
-    fontFamily: fontCss.family.auto.fontFamily,
+    fontFamily: fontCss.family.pretendard.fontFamily,
     height: 450,
     '::before': {
       // placeholder 스타일

--- a/src/components/Lunch/LunchMenusPreview/index.tsx
+++ b/src/components/Lunch/LunchMenusPreview/index.tsx
@@ -100,7 +100,7 @@ const menusCss = css({
 });
 
 const scrollRootCss = css({ width: '100%', paddingBottom: 24 });
-const scrollViewportContentCss = css(flex('center', 'flex-start', 'row', 16));
+const scrollViewportContentCss = css(flex('center', 'space-around', 'row', 16));
 
 const LunchMenusPreviewMenuDescriptionSkeleton = () => {
   const skeletonCount = 4;

--- a/src/components/Profile/PortfolioTabContent/PortfolioError.tsx
+++ b/src/components/Profile/PortfolioTabContent/PortfolioError.tsx
@@ -2,11 +2,10 @@ import { css } from '@emotion/react';
 import * as Sentry from '@sentry/nextjs';
 import { isAxiosError } from 'axios';
 
-import { AlertText } from '~/components/Common/AlertText';
 import { TrackSize } from '~/components/Common/SsafyIcon';
 import { ErrorMessageWithSsafyIcon } from '~/components/ErrorMessageWithSsafyIcon';
 import { flex } from '~/styles/utils';
-import { getErrorResponse, isDevMode, ResponseCode } from '~/utils';
+import { getErrorResponse, isDevMode } from '~/utils';
 
 interface PortfolioErrorProps {
   error: unknown;
@@ -15,30 +14,20 @@ interface PortfolioErrorProps {
 const PortfolioError = (props: PortfolioErrorProps) => {
   const { error } = props;
 
-  if (isAxiosError(error)) {
-    const errorResponse = getErrorResponse(error);
-    const code = errorResponse?.code;
-
-    // 비공개인 경우
-    if (code === ResponseCode.NO_PERMISSIONS) {
-      return (
-        <div css={selfCss}>
-          <ErrorMessageWithSsafyIcon
-            message="포트폴리오 조회 권한이 없습니다"
-            iconSize={TrackSize.LG2}
-          />
-        </div>
-      );
-    }
-  }
-
-  if (!isDevMode) {
+  if (!isAxiosError(error) && !isDevMode) {
     Sentry.captureException(error);
   }
 
+  const errorResponse = getErrorResponse(error);
+  const errorMessage =
+    errorResponse?.message ?? '포트폴리오 로딩 중 오류가 발생했습니다.';
+
   return (
     <div css={selfCss}>
-      <AlertText size="md">포트폴리오 조회중 오류가 발생했습니다</AlertText>
+      <ErrorMessageWithSsafyIcon
+        message={errorMessage}
+        iconSize={TrackSize.LG2}
+      />
     </div>
   );
 };

--- a/src/services/article/utils/articleCss.ts
+++ b/src/services/article/utils/articleCss.ts
@@ -68,5 +68,6 @@ export const articleCss = css(
   linkCss,
   boldCss,
   codeCss,
-  fontCss.style.R14
+  fontCss.style.R14,
+  fontCss.family.pretendard
 );

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -29,13 +29,9 @@ export enum ResponseCode {
 
   // TODO: 값 수정
   APPLICATION_CANCELED = '03030303',
-
-  // TODO: 값 수정
-  NO_PERMISSIONS = '12313312',
 }
 
 export const GlobalSymbol = {
   QUIT_REQUEST_RETRY: Symbol(),
 };
 export type GlobalSymbol = keyof typeof GlobalSymbol;
-


### PR DESCRIPTION
## 구분

- [x] 버그 수정
- [ ] 기능 추가
- [ ] 코드 리팩터링
- [ ] 문서 업데이트
- [ ] 기타

<!-- 어떤 이유로 코드를 변경했는지 체크해주세요. -->

## 주요 변경점

- 이스케이프 처리된 HTML 문자열이 그대로 보이던 문제 해결
- 메인 페이지의 점심메뉴 미리보기 레이아웃 변경 (`justify-content: flex-start` -> `space-around`)

<!-- 주요 변경점과 어떤 부분을 집중해서 리뷰해야 하는지 알려주세요. -->


