### PR TITLE
포트폴리오 - 링크 인풋에서 Enter키 누를 시 Form 제출되는것 막음

### DIFF
--- a/src/components/Forms/PortfolioForm/Fields/Links/LinkField.tsx
+++ b/src/components/Forms/PortfolioForm/Fields/Links/LinkField.tsx
@@ -1,3 +1,4 @@
+import type { KeyboardEventHandler } from 'react';
 import type { UseFieldArrayRemove } from 'react-hook-form';
 import type {
   PortfolioFormLink,
@@ -37,7 +38,7 @@ interface LinkFieldProps {
 
 const LinkField = (props: LinkFieldProps) => {
   const { index, remove } = props;
-  const { register } = usePortfolioFormContext();
+  const { register, setFocus } = usePortfolioFormContext();
   const fieldName = `${fieldArrayName}.${index}` as const;
   const linkTextFieldName = `${fieldName}.linkText` as const;
   const linkFieldName = `${fieldName}.link` as const;
@@ -47,6 +48,24 @@ const LinkField = (props: LinkFieldProps) => {
   }) as PortfolioFormLink;
 
   const removeField = () => remove(index);
+
+  const preventSubmitOnEnterKeyDown: KeyboardEventHandler<HTMLInputElement> = (
+    e
+  ) => {
+    if (e.key === 'Enter') e.preventDefault();
+  };
+
+  const onPressEnterInLink: KeyboardEventHandler<HTMLInputElement> = (e) => {
+    preventSubmitOnEnterKeyDown(e);
+    if (e.key === 'Enter') setFocus(linkTextFieldName);
+  };
+
+  const onPressEnterInLinkText: KeyboardEventHandler<HTMLInputElement> = (
+    e
+  ) => {
+    preventSubmitOnEnterKeyDown(e);
+    if (e.key === 'Enter') setFocus(`${fieldArrayName}.${index + 1}.link`);
+  };
 
   return (
     <div css={selfCss}>
@@ -59,11 +78,13 @@ const LinkField = (props: LinkFieldProps) => {
           inputType={'href'}
           css={linkFieldCss}
           {...register(linkFieldName, { validate: validateLink })}
+          onKeyDown={onPressEnterInLink}
         />
         <PortfolioLinkInputGroup.Input
           inputType={'text'}
           css={linkTextFieldCss}
           {...register(linkTextFieldName, { validate: validateLinkText })}
+          onKeyDown={onPressEnterInLinkText}
         />
         <IconButton
           onClick={removeField}


### PR DESCRIPTION
 

<!-- 이슈 번호를 작성해주세요. 여러 이슈 번호를 작성해도 됩니다. -->

## 구분

- [x] 버그 수정
- [x] 기능 추가
- [ ] 코드 리팩터링
- [ ] 문서 업데이트
- [ ] 기타

<!-- 어떤 이유로 코드를 변경했는지 체크해주세요. -->

## 주요 변경점
- 링크 인풋에서 엔터 누르면 동일 필드의 링크 텍스트로 이동
- 링크 텍스트 인풋에서 엔터 누르면 다음 링크 필드의 링크로 이동


<!-- 주요 변경점과 어떤 부분을 집중해서 리뷰해야 하는지 알려주세요. -->

## 스크린샷

![onEnter 이벤트 핸들러 동작 예시](https://github.com/SSAF-SOUND/ssaf-sound-fe/assets/79135734/ca2ace79-cf04-45ea-84cb-93b29f15b977)

<!-- 관련 미디어 파일이 있으면 첨부해주세요. -->

## 기타

<!-- 추가로 전달할 내용, 메모할 내용, 테스트 계획, 완료된 테스트 등을 알려주세요. -->

