### PR TITLE
링크의 rel 어트리뷰트에 null 값이 들어가는 문제

### DIFF
--- a/src/utils/sanitizeHtml.ts
+++ b/src/utils/sanitizeHtml.ts
@@ -9,7 +9,10 @@ const addHook = () => {
         node.setAttribute('target', '_blank');
 
         const prevRelAttributes = node.getAttribute('rel');
-        node.setAttribute('rel', `${prevRelAttributes} ugc nofollow`);
+        const nextRelAttributes = [prevRelAttributes, 'ugc', 'nofollow']
+          .filter(Boolean)
+          .join(' ');
+        node.setAttribute('rel', nextRelAttributes);
       }
     });
   }


### PR DESCRIPTION
## 구분

- [x] 버그 수정
- [ ] 기능 추가
- [ ] 코드 리팩터링
- [ ] 문서 업데이트
- [ ] 기타

<!-- 어떤 이유로 코드를 변경했는지 체크해주세요. -->

## 주요 변경점

- `Dompurify.addHook`에서 기존 링크 엘리먼트의 rel 어트리뷰트 값이 `null`인 경우 변환되는 링크의 어트리뷰트 값으로 `null`이 포함되는 문제 포함되는 문제 해결

<!-- 주요 변경점과 어떤 부분을 집중해서 리뷰해야 하는지 알려주세요. -->

## 스크린샷


<!-- 관련 미디어 파일이 있으면 첨부해주세요. -->

## 기타

<!-- 추가로 전달할 내용, 메모할 내용, 테스트 계획, 완료된 테스트 등을 알려주세요. -->

