### PR TITLE
스크롤 방향에 따라 GNB UI 노출/숨김

### DIFF
--- a/src/components/Common/Gnb/index.tsx
+++ b/src/components/Common/Gnb/index.tsx
@@ -5,17 +5,21 @@ import { useRouter } from 'next/router';
 
 import { css } from '@emotion/react';
 import { useMemo } from 'react';
-import { MdHome, MdArticle, MdGroupAdd, MdAccountCircle } from 'react-icons/md';
+import { MdAccountCircle, MdArticle, MdGroupAdd, MdHome } from 'react-icons/md';
 
+import {
+  useWindowScrollDirection,
+  WindowScrollDirection,
+} from '~/hooks/useWindowScrollDirection';
 import { useMyInfo } from '~/services/member';
 import {
+  colorMix,
+  fixBottomCenter,
   flex,
   fontCss,
   gnbHeight,
   palettes,
-  fixBottomCenter,
   zIndex,
-  colorMix,
 } from '~/styles/utils';
 import { routes } from '~/utils';
 
@@ -46,6 +50,11 @@ const createNavigationDetail = (
 
 export const Gnb = (props: GnbProps) => {
   const { className } = props;
+  const { windowScrollDirection } = useWindowScrollDirection(
+    WindowScrollDirection.UP
+  );
+  const hide = windowScrollDirection === WindowScrollDirection.DOWN;
+
   const navItems = useMemo(
     () => [
       createNavigationDetail('홈', <MdHome />, routes.main()),
@@ -74,7 +83,10 @@ export const Gnb = (props: GnbProps) => {
   const isSignedIn = !!myInfo;
 
   return (
-    <nav css={selfCss} className={className}>
+    <nav
+      css={[selfCss, hide && hideSelfCss, hoverSelfCss]}
+      className={className}
+    >
       <div css={itemContainerCss}>
         {navItems.map((navItem) => {
           const { text, icon, pathname: itemPathname, auth } = navItem;
@@ -102,7 +114,7 @@ export const Gnb = (props: GnbProps) => {
 };
 
 const selfCss = css(fixBottomCenter, {
-  transition: 'opacity 200ms',
+  transition: 'opacity 200ms, transform 200ms',
   borderTopLeftRadius: 15,
   borderTopRightRadius: 15,
   overflow: 'hidden',
@@ -111,6 +123,16 @@ const selfCss = css(fixBottomCenter, {
   background: palettes.white,
   color: palettes.black,
   zIndex: zIndex.fixed.normal,
+});
+
+const hideSelfCss = css({
+  transform: `translate3d(-50%, ${gnbHeight - 10}px, 0)`,
+});
+
+const hoverSelfCss = css({
+  '&:hover, &:focus-visible': {
+    transform: `translate3d(-50%, 0, 0)`,
+  },
 });
 
 const itemContainerCss = css(

--- a/src/hooks/useWindowScrollDirection.ts
+++ b/src/hooks/useWindowScrollDirection.ts
@@ -1,0 +1,40 @@
+import { useEffect, useRef, useState } from 'react';
+
+export const enum WindowScrollDirection {
+  UP = 'up',
+  DOWN = 'down',
+}
+
+export const useWindowScrollDirection = (
+  initialValue: WindowScrollDirection
+) => {
+  const [windowScrollDirection, setWindowScrollDirection] =
+    useState<WindowScrollDirection>(initialValue);
+  const y = useRef(0);
+
+  useEffect(() => {
+    y.current = window.scrollY;
+
+    const onScroll = () => {
+      const nextY = window.scrollY;
+
+      if (nextY === y.current) return;
+
+      const nextWindowScrollDirection =
+        nextY > y.current
+          ? WindowScrollDirection.DOWN
+          : WindowScrollDirection.UP;
+
+      if (nextWindowScrollDirection !== windowScrollDirection)
+        setWindowScrollDirection(nextWindowScrollDirection);
+
+      y.current = nextY;
+    };
+
+    window.addEventListener('scroll', onScroll);
+
+    return () => window.removeEventListener('scroll', onScroll);
+  }, [windowScrollDirection]);
+
+  return { windowScrollDirection };
+};


### PR DESCRIPTION
## Issues

- #341 

<!-- 이슈 번호를 작성해주세요. 여러 이슈 번호를 작성해도 됩니다. -->

## 구분

- [ ] 버그 수정
- [x] 기능 추가
- [ ] 코드 리팩터링
- [ ] 문서 업데이트
- [ ] 기타

<!-- 어떤 이유로 코드를 변경했는지 체크해주세요. -->

## 주요 변경점

- 스크롤 내릴 때 GNB UI 숨김, 올릴 때 노출
- 숨길 때는 `상단 10px`은 여전히 보여줌 (GNB가 없는 페이지와의 구분을 위해)
- `상단 10px`에 마우스 hover시 일시적으로 GNB 노출. 스크롤 방향이 바뀌지 않았다면 마우스 unhover할 때 GNB 다시 숨김

<!-- 주요 변경점과 어떤 부분을 집중해서 리뷰해야 하는지 알려주세요. -->
