### PR TITLE
게시글 카테고리 데이터 MOCK 데이터로 들어가고 있던 점 수정

### DIFF
--- a/src/components/Forms/ArticleForm/index.tsx
+++ b/src/components/Forms/ArticleForm/index.tsx
@@ -7,7 +7,6 @@ import { FormProvider, useForm } from 'react-hook-form';
 
 import { ArticleCategories } from '~/components/Forms/ArticleForm/Fields/ArticleCategories';
 import TitleBar from '~/components/TitleBar';
-import { articleCategories } from '~/mocks/handlers/article/data';
 import { titleBarHeight } from '~/styles/utils';
 
 import { ArticleTitle, ArticleContent, ArticleOptions } from './Fields';
@@ -35,6 +34,7 @@ export interface ArticleFormProps {
 
 const ArticleForm = (props: ArticleFormProps) => {
   const {
+    articleCategories,
     defaultValues = defaultArticleFormValues,
     onValidSubmit,
     onInvalidSubmit,


### PR DESCRIPTION
<!-- 이슈 번호를 작성해주세요. 여러 이슈 번호를 작성해도 됩니다. -->

## 구분

- [x] 버그 수정
- [ ] 기능 추가
- [ ] 코드 리팩터링
- [ ] 문서 업데이트
- [ ] 기타

<!-- 어떤 이유로 코드를 변경했는지 체크해주세요. -->

## 주요 변경점

- 게시글 폼에 카테고리 데이터가 mock data로 들어가고 있던 점 수정