### PR TITLE
게시글 작성시 카테고리 id 기본값 누락되는 문제

### DIFF
--- a/src/pages/articles/new/index.tsx
+++ b/src/pages/articles/new/index.tsx
@@ -34,7 +34,9 @@ const ArticleCreatePage: CustomNextPage = () => {
 
   const query = router.query as { categoryId: string };
   const { data: articleCategories } = useArticleCategories();
-  const categoryId = Number(query.categoryId);
+  const categoryId = Number(
+    query.categoryId ?? defaultArticleFormValues.category
+  );
 
   useUnloadReconfirmEffect();
 


### PR DESCRIPTION
 

<!-- 이슈 번호를 작성해주세요. 여러 이슈 번호를 작성해도 됩니다. -->

## 구분

- [x] 버그 수정
- [ ] 기능 추가
- [ ] 코드 리팩터링
- [ ] 문서 업데이트
- [ ] 기타

<!-- 어떤 이유로 코드를 변경했는지 체크해주세요. -->

## 주요 변경점

- 게시글 작성시 category id값이 쿼리 파라미터에 없는 경우, form state에 반영되지 않고 ui에만 반영되던 문제 해결
 