### PR TITLE
fix: 이미지에서 fill prop 제거하고, 고정사이즈의 이미지로 변경

### DIFF
--- a/src/components/Lunch/LunchMenusPreview/LunchMenusPreviewMenuDescription.tsx
+++ b/src/components/Lunch/LunchMenusPreview/LunchMenusPreviewMenuDescription.tsx
@@ -12,6 +12,8 @@ export interface LunchMenusPreviewMenuDescriptionProps {
   menu: LunchMenuDetail;
 }
 
+const imageSize = 110;
+
 export const LunchMenusPreviewMenuDescription = (
   props: LunchMenusPreviewMenuDescriptionProps
 ) => {
@@ -32,12 +34,13 @@ export const LunchMenusPreviewMenuDescription = (
             src={imagePath}
             fallbackSrc={lunchImageFallback.src}
             alt={mainMenu}
-            fill={true}
+            width={imageSize}
+            height={imageSize}
             priority={true}
           />
 
           <strong className={cn.mainMenu} css={mainMenuCss}>
-            {mainMenu}
+            {mainMenu}dd
           </strong>
         </div>
       </RadixToggle.Root>
@@ -57,8 +60,6 @@ const likeLayerCss = css(flex('center', '', 'row'), fontCss.style.B16);
 
 const imageContainerCss = css({
   position: 'relative',
-  width: 110,
-  height: 110,
   overflow: 'hidden',
   borderRadius: '50%',
   transition: 'background-color 200ms',
@@ -67,8 +68,6 @@ const imageContainerCss = css({
 const imageCss = css({
   display: 'block',
   objectFit: 'cover',
-  width: '100%',
-  height: '100%',
   transition: 'opacity 200ms',
   opacity: 1,
 });
@@ -78,11 +77,12 @@ const mainMenuCss = css(
     display: 'block',
     position: 'absolute',
     wordBreak: 'break-all',
-    width: '100%',
-    height: '100%',
     padding: 4,
     color: palettes.white,
     opacity: 0,
+    width: '100%',
+    height: '100%',
+    top: 0,
     transition: 'opacity 200ms',
     textAlign: 'center',
   },


### PR DESCRIPTION
## 구분

- [x] 버그 수정
- [ ] 기능 추가
- [ ] 코드 리팩터링
- [ ] 문서 업데이트
- [ ] 기타

<!-- 어떤 이유로 코드를 변경했는지 체크해주세요. -->

## 주요 변경점

- 홈페이지의 점심메뉴 이미지(next/image)에 fill prop을 제거하고 고정 사이즈(`110 x 110`)로 변경

<!-- 주요 변경점과 어떤 부분을 집중해서 리뷰해야 하는지 알려주세요. -->

## 스크린샷


<!-- 관련 미디어 파일이 있으면 첨부해주세요. -->

## 기타

<!-- 추가로 전달할 내용, 메모할 내용, 테스트 계획, 완료된 테스트 등을 알려주세요. -->

