### PR TITLE
알림 메세지 repeat 제거

### DIFF
--- a/src/components/Notification/NotificationItem.tsx
+++ b/src/components/Notification/NotificationItem.tsx
@@ -121,7 +121,7 @@ const NotificationMessage = memo((props: NotificationMessageProps) => {
           size={20}
           css={{ position: 'relative', bottom: -4, marginRight: 6 }}
         />
-        {message.repeat(3)}
+        {message}
       </div>
       {hasLink && <Icon name="chevron.right" size={24} />}
     </>


### PR DESCRIPTION
알림 메세지 길이 제한 테스트 용도로 적용했던 `repeat` 메서드 제거 